### PR TITLE
Handle Verto inbound messages in a service

### DIFF
--- a/packages/web/src/rtc/Dialog.ts
+++ b/packages/web/src/rtc/Dialog.ts
@@ -1,7 +1,6 @@
 import { v4 as uuidv4 } from 'uuid'
 import logger from '../../../common/src/util/logger'
-import SignalWire from '../SignalWire'
-import Verto from '../Verto'
+import BrowserSession from '../BrowserSession'
 import { Invite, Answer, Attach, Bye, Modify, Info } from '../../../common/src/messages/Verto'
 import Peer from './Peer'
 import { PeerType, VertoMethod, SwEvent, NOTIFICATION_TYPE, Direction } from '../../../common/src/util/constants'
@@ -30,7 +29,7 @@ export default class Dialog {
   private gotEarly: boolean = false
   private _lastSerno: number = 0
 
-  constructor(private session: SignalWire | Verto, opts?: DialogOptions) {
+  constructor(private session: BrowserSession, opts?: DialogOptions) {
     const { iceServers, localElement, remoteElement, mediaConstraints: { audio, video } } = session
     this.options = Object.assign({}, DEFAULT_DIALOG_OPTIONS, { audio, video, iceServers, localElement, remoteElement }, opts)
 

--- a/packages/web/src/services/VertoHandler.ts
+++ b/packages/web/src/services/VertoHandler.ts
@@ -109,6 +109,7 @@ class VertoHandler {
           session.broadcast({ channel: laChannel, data: { liveArray: { command: 'bootstrap', context: laChannel, name: laName } } })
         }
         const tmp = {
+          // protocol, // TODO: add Blade protocol here
           channels: [laChannel],
           handler: ({ data: packet }: any) => {
             let dialogId: string = null

--- a/packages/web/src/services/VertoHandler.ts
+++ b/packages/web/src/services/VertoHandler.ts
@@ -1,0 +1,164 @@
+import logger from '../../../common/src/util/logger'
+import BrowserSession from '../BrowserSession'
+import SignalWire from '../SignalWire'
+import Verto from '../Verto'
+
+import Dialog from '../rtc/Dialog'
+import { Result } from '../../../common/src/messages/Verto'
+import { SwEvent, VertoMethod, NOTIFICATION_TYPE } from '../../../common/src/util/constants'
+import { trigger, deRegister } from '../../../common/src/services/Handler'
+import { State, ConferenceAction } from '../../../common/src/util/constants/dialog'
+
+class VertoHandler {
+  constructor(public session: BrowserSession) {
+    // console.log('isBlade?', this.isBlade)
+    // console.log('isVerto?', this.isVerto)
+  }
+
+  handleMessage(msg: any) {
+    const { session } = this
+    const { id, method, params } = msg
+    const { callID: dialogId, eventChannel } = params
+    const attach = method === VertoMethod.Attach
+
+    if (dialogId && session.dialogs.hasOwnProperty(dialogId)) {
+      if (attach) {
+        session.dialogs[dialogId].hangup()
+      } else {
+        session.dialogs[dialogId].handleMessage(msg)
+        session.execute(new Result(id, method))
+        return
+      }
+    }
+
+    switch (method) {
+      case VertoMethod.Punt:
+        if (this.isVerto) {
+          // @ts-ignore
+          session.logout()
+        }
+        break
+      case VertoMethod.Invite:
+      case VertoMethod.Attach:
+        const dialog = new Dialog(session, {
+          id: dialogId,
+          remoteSdp: params.sdp,
+          destinationNumber: params.callee_id_number,
+          remoteCallerName: params.caller_id_name,
+          remoteCallerNumber: params.caller_id_number,
+          callerName: params.callee_id_name,
+          callerNumber: params.callee_id_number,
+          audio: params.sdp.indexOf('m=audio') > 0,
+          video: params.sdp.indexOf('m=video') > 0,
+          attach
+        })
+        if (attach) {
+          dialog.setState(State.Recovering)
+          dialog.answer()
+          dialog.handleMessage(msg)
+        } else {
+          dialog.setState(State.Ringing)
+          session.execute(new Result(id, method))
+        }
+        break
+      case VertoMethod.Event:
+        if (!eventChannel) {
+          logger.error('Verto received an unknown event:', params)
+          return
+        }
+        const firstValue = eventChannel.split('.')[0]
+        if (session.sessionid === eventChannel && params.eventType === 'channelPvtData') {
+          this._handlePvtEvent(params.pvtData)
+        } else if (session.subscriptions.hasOwnProperty(eventChannel)) {
+          trigger(eventChannel, params)
+        } else if (session.subscriptions.hasOwnProperty(firstValue)) {
+          trigger(firstValue, params)
+        } else if (session.dialogs.hasOwnProperty(eventChannel)) {
+          session.dialogs[eventChannel].handleMessage(msg)
+        } else {
+          trigger(SwEvent.Notification, params, session.uuid)
+        }
+        break
+      case VertoMethod.Info:
+        params.type = NOTIFICATION_TYPE.generic
+        trigger(SwEvent.Notification, params, session.uuid)
+        break
+      case VertoMethod.ClientReady:
+        params.type = NOTIFICATION_TYPE.vertoClientReady
+        trigger(SwEvent.Notification, params, session.uuid)
+        break
+      default:
+        logger.warn('Verto message unknown method:', msg)
+    }
+  }
+
+  get isBlade() {
+    return this.session instanceof SignalWire
+  }
+
+  get isVerto() {
+    return this.session instanceof Verto
+  }
+
+  private _handlePvtEvent(pvtData: any) {
+    const { session } = this
+    const { action, laChannel, laName, chatChannel, infoChannel, modChannel, conferenceMemberID, role } = pvtData
+    switch (action) {
+      case 'conference-liveArray-join': {
+        const _liveArrayBootstrap = () => {
+          session.broadcast({ channel: laChannel, data: { liveArray: { command: 'bootstrap', context: laChannel, name: laName } } })
+        }
+        const tmp = {
+          channels: [laChannel],
+          handler: ({ data: packet }: any) => {
+            let dialogId: string = null
+            const dialogIds = Object.keys(session.dialogs)
+            if (packet.action === 'bootObj') {
+              const me = packet.data.find((pr: [string, []]) => dialogIds.includes(pr[0]))
+              if (me instanceof Array) {
+                dialogId = me[0]
+              }
+            } else {
+              dialogId = dialogIds.find((id: string) => session.dialogs[id].channels.includes(laChannel))
+            }
+            if (dialogId && session.dialogs.hasOwnProperty(dialogId)) {
+              const dialog = session.dialogs[dialogId]
+              dialog._addChannel(laChannel)
+              dialog.handleConferenceUpdate(packet, pvtData)
+                .then(error => {
+                  if (error === 'INVALID_PACKET') {
+                    _liveArrayBootstrap()
+                  }
+                })
+            }
+          }
+        }
+        session.subscribe(tmp).then(response => {
+          if (response.subscribedChannels.indexOf(laChannel) >= 0) {
+            _liveArrayBootstrap()
+          }
+        })
+        break
+      }
+      case 'conference-liveArray-part': {
+        // trigger Notification at a Dialog or Session level.
+        // deregister Notification callback at the Dialog level.
+        // Cleanup subscriptions for all channels
+        if (laChannel && session.subscriptions.hasOwnProperty(laChannel)) {
+          const { dialogId = null } = session.subscriptions[laChannel]
+          if (dialogId !== null) {
+            const notification = { type: NOTIFICATION_TYPE.conferenceUpdate, action: ConferenceAction.Leave, conferenceName: laName, participantId: Number(conferenceMemberID), role }
+            if (!trigger(SwEvent.Notification, notification, dialogId, false)) {
+              trigger(SwEvent.Notification, notification, session.uuid)
+            }
+            deRegister(SwEvent.Notification, null, dialogId)
+          }
+        }
+        session.unsubscribe({ channels: [laChannel, chatChannel, infoChannel, modChannel] })
+        break
+      }
+    }
+  }
+}
+
+export default VertoHandler

--- a/packages/web/tests/Verto.test.ts
+++ b/packages/web/tests/Verto.test.ts
@@ -1,10 +1,12 @@
 import behaveLikeBaseSession from '../../common/tests/behaveLike/BaseSession'
+import VertoHandler from './services/VertoHandler'
 import { monitorCallbackQueue } from '../../common/src/services/Handler'
 import Verto from '../src/Verto'
 const Connection = require('../../common/src/services/Connection')
 
 describe('Verto', () => {
   behaveLikeBaseSession.call(this, Verto)
+  VertoHandler.call(this, Verto)
 
   let instance: Verto
   const noop = (): void => { }
@@ -149,13 +151,6 @@ describe('Verto', () => {
       expect(instance.broadcast.bind(instance, { channel: '' })).toThrow()
       expect(instance.broadcast.bind(instance, { channel: false })).toThrow()
       expect(instance.broadcast.bind(instance, { channel: null })).toThrow()
-    })
-  })
-
-  describe('static .uuid()', () => {
-    it('generates UUID v4', () => {
-      const pattern = new RegExp(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i)
-      expect(Verto.uuid()).toMatch(pattern)
     })
   })
 

--- a/packages/web/tests/services/VertoHandler.ts
+++ b/packages/web/tests/services/VertoHandler.ts
@@ -1,0 +1,110 @@
+import BrowserSession from '../../src/BrowserSession'
+import VertoHandler from '../../src/services/VertoHandler'
+import Dialog from '../../src/rtc/Dialog'
+import { State } from '../../../common/src/util/constants/dialog'
+const Connection = require('../../../common/src/services/Connection')
+
+export default (klass: any) => {
+  const DEFAULT_PARAMS = { destinationNumber: 'x3599', remoteCallerName: 'Js Client Test', remoteCallerNumber: '1234', callerName: 'Jest Client', callerNumber: '5678' }
+  describe('VertoHandler', () => {
+    let instance: BrowserSession
+    let handler: VertoHandler
+    let dialog: Dialog
+    const onNotification = jest.fn()
+
+    const _setupDialog = (params: any = {}) => {
+      dialog = new Dialog(instance, { ...DEFAULT_PARAMS, ...params })
+    }
+
+    beforeEach(() => {
+      instance = new klass({ host: 'example.signalwire.com', login: 'login', password: 'password', project: 'project', token: 'token' })
+      onNotification.mockClear()
+      instance.on('signalwire.notification', onNotification)
+      handler = new VertoHandler(instance)
+    })
+
+    afterEach(() => {
+      instance.off('signalwire.notification')
+      Object.keys(instance.dialogs).forEach(k => instance.dialogs[k].setState(State.Purge))
+    })
+
+    describe('verto.punt', () => {
+      it('should initiate the logout process', () => {
+        // FIXME: add logout() method in SignalWire? [abstract from BrowserSession]
+        const msg = JSON.parse('{"jsonrpc":"2.0","id":38,"method":"verto.punt","params":{}}')
+        // @ts-ignore
+        instance.logout = jest.fn()
+        handler.handleMessage(msg)
+        // @ts-ignore
+        expect(instance.logout).toBeCalledTimes(1)
+      })
+    })
+
+    describe('verto.invite', () => {
+      it('should create a new Dialog in ringing state', async done => {
+        await instance.connect()
+        const dialogId = 'cd35e65f-a507-4bd2-8d21-80f36d134a2e'
+        const msg = JSON.parse(`{"jsonrpc":"2.0","id":4402,"method":"verto.invite","params":{"callID":"${dialogId}","sdp":"SDP","caller_id_name":"Extension 1004","caller_id_number":"1004","callee_id_name":"Outbound Call","callee_id_number":"1003","display_direction":"outbound"}}`)
+        handler.handleMessage(msg)
+        expect(instance.dialogs).toHaveProperty(dialogId)
+        expect(instance.dialogs[dialogId].id).toEqual(dialogId)
+        expect(instance.dialogs[dialogId].state).toEqual('ringing')
+        expect(instance.dialogs[dialogId].prevState).toEqual('new')
+        done()
+      })
+    })
+
+    describe('with an active outbound Dialog', () => {
+      beforeEach(async done => {
+        await instance.connect()
+        _setupDialog({ id: 'e2fda6dc-fc9d-4d77-8096-53bb502443b6' })
+        dialog.handleMessage = jest.fn()
+        Connection.mockSend.mockClear()
+        done()
+      })
+
+      describe('verto.media', () => {
+        it('should pass the msg to the dialog and reply back to the server', () => {
+          const msg = JSON.parse('{"jsonrpc":"2.0","id":4403,"method":"verto.media","params":{"callID":"e2fda6dc-fc9d-4d77-8096-53bb502443b6","sdp":"<REMOTE-SDP>"}}')
+          handler.handleMessage(msg)
+          expect(dialog.handleMessage).toBeCalledTimes(1)
+          expect(Connection.mockSend).toHaveBeenLastCalledWith({ request: { jsonrpc: '2.0', id: 4403, result: { method: 'verto.media' } } })
+        })
+      })
+
+      describe('verto.answer', () => {
+        it('should pass the msg to the dialog and reply back to the server', () => {
+          const msg = JSON.parse('{"jsonrpc":"2.0","id":4404,"method":"verto.answer","params":{"callID":"e2fda6dc-fc9d-4d77-8096-53bb502443b6"}}')
+          handler.handleMessage(msg)
+          expect(dialog.handleMessage).toBeCalledTimes(1)
+          expect(Connection.mockSend).toHaveBeenLastCalledWith({ request: { jsonrpc: '2.0', id: 4404, result: { method: 'verto.answer' } } })
+        })
+      })
+    })
+
+    // describe('verto.attach', () => {
+
+    // })
+
+    // describe('verto.event', () => {
+
+    // })
+
+    describe('verto.info', () => {
+      it('should dispatch a notification', () => {
+        handler.handleMessage(JSON.parse('{"jsonrpc":"2.0","id":37,"method":"verto.info","params":{"fake":"data", "test": "data"}}'))
+        expect(onNotification).toBeCalledWith({ type: 'event', fake: 'data', test: 'data' })
+      })
+    })
+
+    describe('verto.clientReady', () => {
+      it('should dispatch a notification', () => {
+        handler.handleMessage(JSON.parse('{"jsonrpc":"2.0","id":37,"method":"verto.clientReady","params":{"reattached_sessions":[]}}'))
+        expect(onNotification).toBeCalledWith({ type: 'vertoClientReady', reattached_sessions: [] })
+
+        handler.handleMessage(JSON.parse('{"jsonrpc":"2.0","id":37,"method":"verto.clientReady","params":{"reattached_sessions":["test"]}}'))
+        expect(onNotification).toBeCalledWith({ type: 'vertoClientReady', reattached_sessions: ['test'] })
+      })
+    })
+  })
+}


### PR DESCRIPTION
Move logic from Verto.ts to a separated service to re-use it under Relay