### PR TITLE
Using tag to setup new Calls

### DIFF
--- a/packages/common/src/util/interfaces.ts
+++ b/packages/common/src/util/interfaces.ts
@@ -183,7 +183,7 @@ export interface ICallPeer {
 }
 
 export interface ICallOptions {
-  device: ICallDevice
+  device?: ICallDevice
   peer?: ICallPeer
   node_id?: string
   call_id?: string

--- a/packages/node/examples/calling/index.js
+++ b/packages/node/examples/calling/index.js
@@ -110,7 +110,9 @@ function _init() {
               call.hangup()
               return null
             })
-          console.log(`\tCall connected?`, connectResponse)
+          if (connectResponse) {
+            console.log(`\tCall connected?`, connectResponse.id, connectResponse.peer.id)
+          }
         })
       }
 

--- a/packages/node/src/relay/calling/Call.ts
+++ b/packages/node/src/relay/calling/Call.ts
@@ -264,6 +264,10 @@ export default class Call implements ICall {
     return this.relayInstance.getCallById(call_id)
   }
 
+  setOptions(opts: ICallOptions) {
+    this.options = { ...this.options, ...opts }
+  }
+
   get device(): ICallDevice {
     return this.options.device
   }

--- a/packages/node/src/relay/calling/Call.ts
+++ b/packages/node/src/relay/calling/Call.ts
@@ -8,8 +8,7 @@ import { reduceConnectParams } from '../helpers'
 import Calling from './Calling'
 
 export default class Call implements ICall {
-  public tag: string = uuidv4()
-  public id: string
+  public id: string = `local-${uuidv4()}`
   public nodeId: string
 
   private _prevState: number = 0
@@ -23,15 +22,10 @@ export default class Call implements ICall {
   }
 
   setup(callId: string, nodeId: string) {
-    if (this._state > CallState.none) {
-      return
-    }
-    this._state = CallState.created
+    console.log(' - SETUP! - ', callId, nodeId, this.id)
     this.id = callId
     this.nodeId = nodeId
     this._attachListeners()
-    this.relayInstance.addCall(this)
-    trigger(this.id, this, this.state, false)
   }
 
   async begin() {
@@ -40,10 +34,12 @@ export default class Call implements ICall {
       protocol,
       method: 'call.begin',
       params: {
-        tag: this.tag,
+        tag: this.id,
         device: this.device
       }
     })
+
+    this.relayInstance.addCall(this)
 
     const response = await session.execute(msg).catch(error => error)
     const { result } = response
@@ -56,8 +52,6 @@ export default class Call implements ICall {
       logger.error('Begin call not 200', call_id, code, node_id)
       throw new Error('Error creating the call')
     }
-
-    this.setup(call_id, node_id)
   }
 
   async hangup() {

--- a/packages/node/src/relay/calling/Calling.ts
+++ b/packages/node/src/relay/calling/Calling.ts
@@ -89,12 +89,4 @@ export default class Calling extends Relay {
   getCallByTag(tag: string): Call {
     return this._calls.find(call => call.tag === tag)
   }
-
-  // callExists(callId: string): boolean {
-  //   return this.callIds().includes(callId)
-  // }
-
-  // callIds(): string[] {
-  //   return Object.keys(this._calls)
-  // }
 }

--- a/packages/node/src/relay/calling/Calling.ts
+++ b/packages/node/src/relay/calling/Calling.ts
@@ -42,8 +42,10 @@ export default class Calling extends Relay {
         break
       }
       case 'calling.call.connect': {
-        const { call_id, connect_state } = params
-        trigger(call_id, this.getCallById(call_id), connect_state)
+        const { call_id, connect_state, peer } = params
+        const call = this.getCallById(call_id)
+        call.setOptions({ peer } )
+        trigger(call_id, call, connect_state)
         break
       }
     }

--- a/packages/node/src/relay/calling/Calling.ts
+++ b/packages/node/src/relay/calling/Calling.ts
@@ -18,11 +18,13 @@ export default class Calling extends Relay {
     switch (event_type) {
       case 'calling.call.state': {
         const { call_id, node_id, call_state, tag } = params
-        const call = this.getCall(call_id) || this.getCallByTag(tag)
+        const call = this.getCall(call_id) || this.getCall(tag)
         if (!call) {
           throw new Error(`Unknown call id: '${call_id}' tag: '${tag}' state: ${call_state}`)
         }
-        call.setup(call_id, node_id)
+        if (call.id.indexOf('local-') === 0) {
+          call.setup(call_id, node_id)
+        }
         trigger(call.id, call, call_state, false)
         break
       }
@@ -80,10 +82,5 @@ export default class Calling extends Relay {
 
   callIds(): string[] {
     return Object.keys(this._calls)
-  }
-
-  getCallByTag(tag: string) {
-    const callId = this.callIds().find(id => this._calls[id].tag === tag)
-    return this.getCall(callId)
   }
 }

--- a/packages/node/tests/relay/Call.test.ts
+++ b/packages/node/tests/relay/Call.test.ts
@@ -38,10 +38,14 @@ describe('Call', () => {
       call = new Call(session.calling, { device })
     })
 
-    it('should create the Call object and do nothing else', () => {
+    it('should create the Call object with no id and nodeId', () => {
       expect(call.state).toEqual('none')
       expect(call.id).toBeUndefined()
-      expect(session.calling.addCall).not.toHaveBeenCalled()
+      expect(call.nodeId).toBeUndefined()
+    })
+
+    it('should add the call to the cache array', () => {
+      expect(session.calling.addCall).toHaveBeenCalledWith(call)
     })
 
     it('should not have peers', () => {


### PR DESCRIPTION
Use new `created` notification to setup listeners on newly created calls.