### PR TITLE
Call type as param

### DIFF
--- a/packages/common/src/util/helpers.ts
+++ b/packages/common/src/util/helpers.ts
@@ -15,18 +15,6 @@ export const validateOptions = (options: ISignalWireOptions, className: string):
   return Boolean(host) && check
 }
 
-export const cleanNumber = (_num: string = ''): string => {
-  let num: string = ''
-  try { num = _num.replace(/\D/g, '') } catch { }
-  if (num.length < 10) { // FIXME: We need a better check here!
-    return null
-  }
-  if (!/^1/.test(num)) {
-    num = `1${num}`
-  }
-  return `+${num}`
-}
-
 export const objEmpty = (obj: Object) => Object.keys(obj).length === 0
 
 export const mutateStorageKey = (key: string) => `${STORAGE_PREFIX}${key}`

--- a/packages/common/src/util/interfaces.ts
+++ b/packages/common/src/util/interfaces.ts
@@ -192,6 +192,7 @@ export interface ICallOptions {
 }
 
 export interface IMakeCallParams {
+  type: string
   from: string
   to: string
   timeout?: number

--- a/packages/common/tests/helpers.test.ts
+++ b/packages/common/tests/helpers.test.ts
@@ -1,23 +1,6 @@
-import { cleanNumber, objEmpty, mutateLiveArrayData, safeParseJson, isDefined } from '../src/util/helpers'
+import { objEmpty, mutateLiveArrayData, safeParseJson, isDefined } from '../src/util/helpers'
 
 describe('Helpers functions', () => {
-  describe('cleanNumber', () => {
-    it('should clear a number starting with 1', () => {
-      const number = '1-650.382.0000'
-      expect(cleanNumber(number)).toEqual('+16503820000')
-    })
-    it('should clear a number not starting with 1', () => {
-      const number = '650.382.0000'
-      expect(cleanNumber(number)).toEqual('+16503820000')
-    })
-    it('should clear a number already cleaned', () => {
-      const number = '+6503820000'
-      expect(cleanNumber(number)).toEqual('+16503820000')
-      const number2 = '+16503820000'
-      expect(cleanNumber(number2)).toEqual('+16503820000')
-    })
-  })
-
   describe('objEmpty', () => {
     it('should return true if object has no values', () => {
       const tmp = { test: 1234 }

--- a/packages/node/src/relay/calling/Calling.ts
+++ b/packages/node/src/relay/calling/Calling.ts
@@ -3,7 +3,6 @@ import { isFunction } from '../../../../common/src/util/helpers'
 import { register, trigger } from '../../../../common/src/services/Handler'
 import { ICallDevice, IMakeCallParams } from '../../../../common/src/util/interfaces'
 import logger from '../../../../common/src/util/logger'
-import { cleanCallingParams } from '../helpers'
 import Relay from '../Relay'
 import Call from './Call'
 
@@ -52,7 +51,7 @@ export default class Calling extends Relay {
   }
 
   async makeCall(params: IMakeCallParams) {
-    const { type, from_number, to_number, timeout } = cleanCallingParams(params)
+    const { type, from: from_number, to: to_number, timeout = 30 } = params
     if (!type || !from_number || !to_number || !timeout) {
       throw new Error(`Invalid parameters for 'makeCall'.`)
     }

--- a/packages/node/src/relay/helpers.ts
+++ b/packages/node/src/relay/helpers.ts
@@ -1,56 +1,20 @@
-import { CallType } from '../../../common/src/util/constants/relay'
-import { cleanNumber } from '../../../common/src/util/helpers'
-import { ICallDevice, IMakeCallParams } from '../../../common/src/util/interfaces'
+import { ICallDevice } from '../../../common/src/util/interfaces'
 
 interface DeepArray<T> extends Array<T | DeepArray<T>> { }
-
-export const detectCallType = (_to: string = ''): CallType => {
-  let to: string = ''
-  try { to = _to.trim() } catch {}
-  if (!to) {
-    return null
-  }
-  if (/^sip:/.test(to)) {
-    return CallType.Sip
-  }
-  if (cleanNumber(to)) {
-    return CallType.Phone
-  }
-  return CallType.WebRTC
-}
 
 interface DeviceAccumulator {
   devices: DeepArray<ICallDevice>,
   nested: boolean
 }
 
-export const cleanCallingParams = (params: IMakeCallParams): { type: CallType, from_number: string, to_number: string, timeout: number } => {
-  const { from = '', to = '', timeout = 30 } = params
-  const type = detectCallType(to)
-  switch (type) {
-    case CallType.Phone:
-      return { type, from_number: cleanNumber(from), to_number: cleanNumber(to), timeout: Number(timeout) }
-    case CallType.Sip:
-    case CallType.WebRTC:
-      return { type, from_number: from.trim(), to_number: to.trim(), timeout: Number(timeout) }
-  }
-  return { type, from_number: from, to_number: to, timeout: Number(timeout) }
-}
-
 export const reduceConnectParams = (peers: any[], callDevice: ICallDevice): DeepArray<ICallDevice> => {
   const { params: { from_number: defaultFromNumber, timeout: defaultTimeout } } = callDevice
-  const _reducer = (accumulator: DeviceAccumulator, peer: any, currentIndex: number, sourceArray: any[]) => {
+  const _reducer = (accumulator: DeviceAccumulator, peer: any) => {
     let tmp: ICallDevice = null
     if (peer instanceof Array) {
       tmp = peer.reduce(_reducer, { devices: [], nested: true }).devices
-    } else if (typeof peer === 'string') {
-      const { type, from_number, to_number, timeout } = cleanCallingParams({ from: defaultFromNumber, to: peer, timeout: defaultTimeout })
-      if (type) {
-        tmp = { type, params: { to_number, from_number, timeout } }
-      }
     } else if (typeof peer === 'object') {
-      const { to, from = defaultFromNumber, timeout: _timeout = defaultTimeout } = peer
-      const { type, from_number, to_number, timeout } = cleanCallingParams({ from, to, timeout: _timeout })
+      const { type, from: from_number = defaultFromNumber, to: to_number, timeout = defaultTimeout } = peer
       if (type) {
         tmp = { type, params: { to_number, from_number, timeout } }
       }

--- a/packages/node/tests/relay/calling.test.ts
+++ b/packages/node/tests/relay/calling.test.ts
@@ -47,7 +47,7 @@ describe('Calling', () => {
 
     let call: Call
     beforeEach(async done => {
-      call = await session.calling.makeCall({ from: '8992222222', to: '8991111111' })
+      call = await session.calling.makeCall({ type: 'phone', from: '8992222222', to: '8991111111' })
       done()
     })
 

--- a/packages/node/tests/relay/helpers.test.ts
+++ b/packages/node/tests/relay/helpers.test.ts
@@ -2,70 +2,69 @@ import { reduceConnectParams } from '../../src/relay/helpers'
 import { ICallDevice } from '../../../common/src/util/interfaces'
 
 describe('reduceConnectParams()', () => {
-  const from_number = '8992222222'
-  const from_number_cleaned = '+18992222222'
-  const to_number = '8991111111'
-  const to_number_cleaned = '+18991111111'
+  const from_number = '+18992222222'
+  const to_number = '+18991111111'
   const timeout = 30
   const type = 'phone'
   const DEFAULT_DEVICE: ICallDevice = { type, params: { from_number, timeout, to_number: '' } }
+
   it('should return a single device to call', () => {
     const res = [
-      [{ type, params: { to_number: to_number_cleaned, from_number: from_number_cleaned, timeout } }]
+      [{ type, params: { to_number, from_number, timeout } }]
     ]
-    const input = [to_number]
+    const input = [{ type, to: to_number }]
     expect(reduceConnectParams(input, DEFAULT_DEVICE)).toEqual(res)
   })
 
   it('should return a single device to call specifying from and timeout', () => {
     const res = [
-      [{ type, params: { to_number: to_number_cleaned, from_number: from_number_cleaned, timeout: 50 } }]
+      [{ type, params: { to_number, from_number, timeout: 50 } }]
     ]
-    const input = [{ to: to_number, from: from_number, timeout: 50 }]
+    const input = [{ type, to: to_number, from: from_number, timeout: 50 }]
     expect(reduceConnectParams(input, DEFAULT_DEVICE)).toEqual(res)
   })
 
   it('should return multiple devices to call in serial', () => {
     const res = [
-      [{ type, params: { to_number: to_number_cleaned, from_number: from_number_cleaned, timeout } }],
-      [{ type, params: { to_number: '+18991111112', from_number: from_number_cleaned, timeout } }]
+      [{ type, params: { to_number, from_number, timeout } }],
+      [{ type, params: { to_number: '8991111112', from_number, timeout } }]
     ]
-    const input = [to_number, '8991111112']
+    const input = [{ type, to: to_number }, { type, to: '8991111112' }]
     expect(reduceConnectParams(input, DEFAULT_DEVICE)).toEqual(res)
   })
 
   it('should return multiple devices to call in serial specifying from and timeout', () => {
     const res = [
-      [{ type, params: { to_number: to_number_cleaned, from_number: from_number_cleaned, timeout: 10 } }],
-      [{ type, params: { to_number: '+18991111112', from_number: '+18992222223', timeout: 20 } }]
+      [{ type, params: { to_number, from_number, timeout: 10 } }],
+      [{ type, params: { to_number: '8991111112', from_number: '8992222223', timeout: 20 } }]
     ]
     const input = [
-      { to: to_number, from: from_number, timeout: 10 },
-      { to: '8991111112', from: '8992222223', timeout: 20 }
+      { type, to: to_number, from: from_number, timeout: 10 },
+      { type, to: '8991111112', from: '8992222223', timeout: 20 }
     ]
     expect(reduceConnectParams(input, DEFAULT_DEVICE)).toEqual(res)
   })
 
   it('should return multiple devices to call in parallel', () => {
     const res = [[
-      { type, params: { to_number: to_number_cleaned, from_number: from_number_cleaned, timeout } },
-      { type, params: { to_number: '+18991111112', from_number: from_number_cleaned, timeout } }
+      { type, params: { to_number, from_number, timeout } },
+      { type, params: { to_number: '8991111112', from_number, timeout } }
     ]]
     const input = [
-      [to_number, '8991111112']
+      [{ type, to: to_number }, { type, to: '8991111112' }]
     ]
     expect(reduceConnectParams(input, DEFAULT_DEVICE)).toEqual(res)
   })
 
   it('should return multiple devices to call in parallel specifying from and timeout', () => {
     const res = [[
-      { type, params: { to_number: to_number_cleaned, from_number: from_number_cleaned, timeout } },
-      { type, params: { to_number: '+18991111119', from_number: '+18992222229', timeout: 20 } }
+      { type, params: { to_number, from_number, timeout } },
+      { type, params: { to_number: '8991111119', from_number: '8992222229', timeout: 20 } }
     ]]
     const input = [
       [
-        { to: to_number, from: from_number, timeout },
-        { to: '18991111119', from: '8992222229', timeout: 20 }
+        { type, to: to_number, from: from_number, timeout },
+        { type, to: '8991111119', from: '8992222229', timeout: 20 }
       ]
     ]
     expect(reduceConnectParams(input, DEFAULT_DEVICE)).toEqual(res)
@@ -73,37 +72,37 @@ describe('reduceConnectParams()', () => {
 
   it('should return multiple devices to call in both serial & parallel', () => {
     const res = [
-      [{ type, params: { to_number: to_number_cleaned, from_number: from_number_cleaned, timeout } }],
+      [{ type, params: { to_number, from_number, timeout } }],
       [
-        { type, params: { to_number: to_number_cleaned, from_number: from_number_cleaned, timeout } },
-        { type, params: { to_number: '+18991111112', from_number: from_number_cleaned, timeout } }
+        { type, params: { to_number, from_number, timeout } },
+        { type, params: { to_number: '8991111112', from_number, timeout } }
       ],
-      [{ type, params: { to_number: '+18991111113', from_number: from_number_cleaned, timeout } }]
+      [{ type, params: { to_number: '8991111113', from_number, timeout } }]
     ]
     const input = [
-      to_number,
-      [to_number, '8991111112'],
-      '8991111113'
+      { type, to: to_number },
+      [{ type, to: to_number }, { type, to: '8991111112' }],
+      { type, to: '8991111113' }
     ]
     expect(reduceConnectParams(input, DEFAULT_DEVICE)).toEqual(res)
   })
 
   it('should return multiple devices to call in both serial & parallel specifying from and timeout', () => {
     const res = [
-      [{ type, params: { to_number: to_number_cleaned, from_number: from_number_cleaned, timeout } }],
+      [{ type, params: { to_number, from_number, timeout } }],
       [
-        { type, params: { to_number: to_number_cleaned, from_number: '+18992222223', timeout: 25 } },
-        { type, params: { to_number: '+18991111112', from_number: '+18992222224', timeout: 25 } }
+        { type, params: { to_number, from_number: '8992222223', timeout: 25 } },
+        { type, params: { to_number: '8991111112', from_number: '8992222224', timeout: 25 } }
       ],
-      [{ type, params: { to_number: '+18991111113', from_number: '+18992222225', timeout } }]
+      [{ type, params: { to_number: '8991111113', from_number: '8992222225', timeout } }]
     ]
     const input = [
-      { to: to_number, from: from_number, timeout },
+      { type, to: to_number, from: from_number, timeout },
       [
-        { to: to_number, from: '8992222223', timeout: 25 },
-        { to: '8991111112', from: '8992222224', timeout: 25 }
+        { type, to: to_number, from: '8992222223', timeout: 25 },
+        { type, to: '8991111112', from: '8992222224', timeout: 25 }
       ],
-      { to: '8991111113', from: '8992222225', timeout }
+      { type, to: '8991111113', from: '8992222225', timeout }
     ]
     expect(reduceConnectParams(input, DEFAULT_DEVICE)).toEqual(res)
   })
@@ -116,26 +115,27 @@ describe('reduceConnectParams()', () => {
 
     it('should ignore invalid string to call in serial', () => {
       const res = [
-        [{ type, params: { to_number: '+18991111112', from_number: from_number_cleaned, timeout } }]
+        [{ type, params: { to_number: '8991111112', from_number, timeout } }]
       ]
-      expect(reduceConnectParams(['', '8991111112'], DEFAULT_DEVICE)).toEqual(res)
+      const input = ['', { type, to: '8991111112' }]
+      expect(reduceConnectParams(input, DEFAULT_DEVICE)).toEqual(res)
     })
 
     it('should ignore invalid input in both serial & parallel specifying from and timeout', () => {
       const res = [
         [
-          { type, params: { to_number: to_number_cleaned, from_number: from_number_cleaned, timeout } }
+          { type, params: { to_number, from_number, timeout } }
         ],
         [
-          { type, params: { to_number: '+18991111112', from_number: '+18992222226', timeout: 25 } }
+          { type, params: { to_number: '8991111112', from_number: '8992222226', timeout: 25 } }
         ]
       ]
       const input = [
-        { to: to_number, from: from_number, timeout },
+        { type, to: to_number, from: from_number, timeout },
         [
           { from: '7778', timeout: 25 },
           { to: '', from: '7772', timeout: 25 },
-          { to: '8991111112', from: '8992222226', timeout: 25 }
+          { type, to: '8991111112', from: '8992222226', timeout: 25 }
         ],
         { to: '', from: '7780', timeout }
       ]

--- a/packages/node/tests/relay/helpers.test.ts
+++ b/packages/node/tests/relay/helpers.test.ts
@@ -1,24 +1,5 @@
-import { detectCallType, reduceConnectParams } from '../../src/relay/helpers'
+import { reduceConnectParams } from '../../src/relay/helpers'
 import { ICallDevice } from '../../../common/src/util/interfaces'
-
-describe('detectCallType()', () => {
-  it('detect phone call type', () => {
-    expect(detectCallType('(204) 222-9999')).toEqual('phone')
-    expect(detectCallType('+1 (204) 222-9999')).toEqual('phone')
-    expect(detectCallType('1 (204) 222-9999')).toEqual('phone')
-  })
-
-  it('detect SIP call type', () => {
-    expect(detectCallType('sip:joe.smith@127.0.0.1')).toEqual('sip')
-    expect(detectCallType('sip:test@sip.example.com')).toEqual('sip')
-    expect(detectCallType('sip:22444032@sip.example.com:6000')).toEqual('sip')
-  })
-
-  it('detect WebRTC call type', () => {
-    expect(detectCallType('1008')).toEqual('webrtc')
-    expect(detectCallType('1009-conf-admin')).toEqual('webrtc')
-  })
-})
 
 describe('reduceConnectParams()', () => {
   const from_number = '8992222222'


### PR DESCRIPTION
Remove input parametes cleanup and require call `type` params to make a new call.