### PR TITLE
tweak signalwire space hosts

### DIFF
--- a/packages/common/src/services/Connection.ts
+++ b/packages/common/src/services/Connection.ts
@@ -1,7 +1,7 @@
 import logger from '../util/logger'
 import BaseSession from '../BaseSession'
 import { SwEvent } from '../util/constants'
-import { safeParseJson } from '../util/helpers'
+import { safeParseJson, checkWebSocketHost } from '../util/helpers'
 import { registerOnce, trigger } from '../services/Handler'
 
 let WebSocketClass: any = typeof WebSocket !== 'undefined' ? WebSocket : null
@@ -17,7 +17,7 @@ const WS_STATE = {
 }
 
 const REQUEST_TIMEOUT = 10 * 1000
-const PATTERN = /^(ws|wss):\/\//
+
 export default class Connection {
   private _wsClient: any = null
   private _host: string = 'wss://localhost:2100'
@@ -27,9 +27,7 @@ export default class Connection {
   public downDur: number = null
 
   constructor(public session: BaseSession) {
-    const { host } = session.options
-    const protocol = PATTERN.test(host) ? '' : 'wss://'
-    this._host = `${protocol}${session.options.host}`
+    this._host = checkWebSocketHost(session.options.host)
     this.connect()
   }
 

--- a/packages/common/src/util/helpers.ts
+++ b/packages/common/src/util/helpers.ts
@@ -60,3 +60,12 @@ export const findElementByType = (tag: HTMLMediaElement | string | Function): HT
   }
   return null
 }
+
+const PROTOCOL_PATTERN = /^(ws|wss):\/\//
+const SW_SPACE_PATTERN = /\.signalwire\.com$/
+
+export const checkWebSocketHost = (host: string): string => {
+  const protocol = PROTOCOL_PATTERN.test(host) ? '' : 'wss://'
+  const suffix = SW_SPACE_PATTERN.test(host) ? ':443/api/relay/wss' : ''
+  return `${protocol}${host}${suffix}`
+}

--- a/packages/common/tests/helpers.test.ts
+++ b/packages/common/tests/helpers.test.ts
@@ -1,4 +1,4 @@
-import { objEmpty, mutateLiveArrayData, safeParseJson, isDefined } from '../src/util/helpers'
+import { objEmpty, mutateLiveArrayData, safeParseJson, isDefined, checkWebSocketHost } from '../src/util/helpers'
 
 describe('Helpers functions', () => {
   describe('objEmpty', () => {
@@ -50,5 +50,37 @@ describe('Helpers functions', () => {
       delete obj.key
       expect(isDefined(obj.key)).toEqual(false)
     })
+  })
+
+  describe('checkWebSocketHost()', () => {
+
+    describe('on a signalwire space', () => {
+      it('should add wss protocol and suffix if not present', () => {
+        expect(checkWebSocketHost('example.signalwire.com')).toEqual('wss://example.signalwire.com:443/api/relay/wss')
+      })
+
+      it('should dont add suffix if its already specified', () => {
+        const hostOk = 'wss://example.signalwire.com:9999/something/else'
+        expect(checkWebSocketHost('example.signalwire.com:9999/something/else')).toEqual(hostOk)
+        expect(checkWebSocketHost(hostOk)).toEqual(hostOk)
+      })
+
+      it('should do nothing with protocol and suffix already specified', () => {
+        expect(checkWebSocketHost('ws://example.signalwire.com:8888')).toEqual('ws://example.signalwire.com:8888')
+      })
+    })
+
+    describe('on an host that is not a signalwire space', () => {
+      it('should add wss protocol if not present', () => {
+        expect(checkWebSocketHost('example.com')).toEqual('wss://example.com')
+        expect(checkWebSocketHost('test.example.com:8082')).toEqual('wss://test.example.com:8082')
+      })
+
+      it('should do nothing if protocol is already present', () => {
+        expect(checkWebSocketHost('ws://example.com')).toEqual('ws://example.com')
+        expect(checkWebSocketHost('wss://test.example.com:8082')).toEqual('wss://test.example.com:8082')
+      })
+    })
+
   })
 })

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalwire/node",
-  "version": "0.0.1",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalwire/node",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Client library for connecting to SignalWire.",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "main": "dist/node/index.js",


### PR DESCRIPTION
Append `:443/api/relay/wss` if it's a SW space domain. FS standalone compatibility