### PR TITLE
Handle ws/login errors

### DIFF
--- a/packages/common/src/BaseSession.ts
+++ b/packages/common/src/BaseSession.ts
@@ -227,8 +227,8 @@ export default abstract class BaseSession {
    * Callback when the ws connection give an error
    * @return void
    */
-  protected _onSocketError(error) {
-    logger.error('Socket error', error)
+  protected _onSocketError(error: Error) {
+    logger.error(error.message)
   }
 
   /**

--- a/packages/common/src/BaseSession.ts
+++ b/packages/common/src/BaseSession.ts
@@ -127,6 +127,7 @@ export default abstract class BaseSession {
    */
   disconnect() {
     trigger(SwEvent.Disconnect, null, this.uuid, false)
+    this._autoReconnect = false
     this._removeConnection()
     this.purge()
     this._executeQueue = []
@@ -364,7 +365,6 @@ export default abstract class BaseSession {
   private _removeConnection() {
     this._idle = true
     if (this.connection) {
-      this._autoReconnect = false
       this.connection.close()
     }
     this.connection = null

--- a/packages/web/src/Verto.ts
+++ b/packages/web/src/Verto.ts
@@ -50,11 +50,6 @@ export default class Verto extends BrowserSession {
     }
   }
 
-  protected _onSocketClose() {
-    logger.info('Verto socket close')
-    setTimeout(() => this.connect(), 1000)
-  }
-
   protected _onSocketMessage(msg: any) {
     const handler = new VertoHandler(this)
     handler.handleMessage(msg)

--- a/packages/web/src/Verto.ts
+++ b/packages/web/src/Verto.ts
@@ -42,10 +42,7 @@ export default class Verto extends BrowserSession {
     const sessid = await Storage.getItem(SESSID)
     const { login, password, passwd, userVariables } = this.options
     const msg = new Login(login, (password || passwd), sessid, userVariables)
-    const response = await this.execute(msg)
-      .catch(error => {
-        trigger(SwEvent.Error, error, this.uuid)
-      })
+    const response = await this.execute(msg).catch(this._handleLoginError)
     if (response) {
       this.sessionid = response.sessid
       Storage.setItem(SESSID, this.sessionid)

--- a/packages/web/src/Verto.ts
+++ b/packages/web/src/Verto.ts
@@ -58,10 +58,6 @@ export default class Verto extends BrowserSession {
     setTimeout(() => this.connect(), 1000)
   }
 
-  protected _onSocketError(error) {
-    logger.error('Verto socket error', error)
-  }
-
   protected _onSocketMessage(msg: any) {
     const handler = new VertoHandler(this)
     handler.handleMessage(msg)


### PR DESCRIPTION
- Display only socket error msg instead of the object
- Centralized `verto login`/`blade.connect` error handling