### PR TITLE
Check resolution for each video device available

### DIFF
--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Expose static method uuid().
 ### Changed
 - client.connect() is now async to check browser permissions before open the websocket connection.
+- client.supportedResolutions() now returns a device list for each resolution supported.
 ### Removed
 - `chatChannel` / `infoChannel` / `conferenceChannel` have been removed from the `conferenceUpdate` notification (**join** & **leave** actions).
 ### Security

--- a/packages/web/src/rtc/helpers.ts
+++ b/packages/web/src/rtc/helpers.ts
@@ -66,7 +66,7 @@ const getResolutions = async (): Promise<ICacheResolution[]> => {
     for (let i = 0; i < resolutionList.length; i++) {
       const [width, height] = resolutionList[i]
       const resolution = { resolution: `${width}x${height}`, width, height, devices: [] }
-      for (let y = videoDevices.length - 1; y >= 0; y--) {
+      for (let y = 0; y < videoDevices.length; y++) {
         try {
           const constraints = { video: { width: { exact: width }, height: { exact: height }, deviceId: { exact: videoDevices[y].deviceId } } }
           const stream = await getUserMedia(constraints)

--- a/packages/web/src/rtc/helpers.ts
+++ b/packages/web/src/rtc/helpers.ts
@@ -54,18 +54,32 @@ const getDevices = async (): Promise<ICacheDevices> => {
 
 const resolutionList = [[160, 120], [176, 144], [320, 240], [352, 288], [640, 360], [640, 480], [800, 600], [1280, 720], [1600, 1200], [1920, 1080], [3840, 2160]]
 const getResolutions = async (): Promise<ICacheResolution[]> => {
+  let videoDevices = []
+  try {
+    const devices = await navigator.mediaDevices.enumerateDevices()
+    videoDevices = devices.filter(d => d.kind === 'videoinput')
+  } catch (error) {
+    return []
+  }
   const supported = []
-  for (let i = 0; i < resolutionList.length; i++) {
-    const resolution = resolutionList[i]
-    const constraints = { audio: false, video: { width: { exact: resolution[0] }, height: { exact: resolution[1] } } }
-    const stream = await getUserMedia(constraints).catch(error => null)
-    if (stream) {
-      stream.getVideoTracks().forEach((t: MediaStreamTrack) => {
-        supported.push(Object.assign({ resolution: `${resolution[0]}x${resolution[1]}` }, t.getSettings()))
-        t.stop()
-      })
+  if (videoDevices.length) {
+    for (let i = 0; i < resolutionList.length; i++) {
+      const [width, height] = resolutionList[i]
+      const resolution = { resolution: `${width}x${height}`, width, height, devices: [] }
+      for (let y = videoDevices.length - 1; y >= 0; y--) {
+        try {
+          const constraints = { video: { width: { exact: width }, height: { exact: height }, deviceId: { exact: videoDevices[y].deviceId } } }
+          const stream = await getUserMedia(constraints)
+          stream.getVideoTracks().forEach(t => t.stop())
+          resolution.devices.push( Object.assign(videoDevices[y]) )
+        } catch {}
+      }
+      if (resolution.devices.length) {
+        supported.push(resolution)
+      }
     }
   }
+
   return supported
 }
 


### PR DESCRIPTION
`client.supportedResolutions()` now checks resolution for each video devices instead of using just the default one.