### PR TITLE
JWT Auth for web client

### DIFF
--- a/packages/common/src/BaseSession.ts
+++ b/packages/common/src/BaseSession.ts
@@ -20,6 +20,7 @@ export default abstract class BaseSession {
 
   protected connection: Connection = null
   protected _relayInstances: { [service: string]: Relay } = {}
+  protected _jwtAuth: boolean = false
 
   private _cache: Cache
   private _idle: boolean = false
@@ -28,7 +29,7 @@ export default abstract class BaseSession {
 
   constructor(public options: ISignalWireOptions) {
     if (!this.validateOptions()) {
-      throw new Error('SignalWire: Invalid init options')
+      throw new Error('Invalid init options')
     }
     this._onSocketOpen = this._onSocketOpen.bind(this)
     this._onSocketClose = this._onSocketClose.bind(this)
@@ -204,7 +205,9 @@ export default abstract class BaseSession {
    */
   protected async _onSocketOpen() {
     this._idle = false
-    const bc = new Connect({ project: this.options.project, token: this.options.token }, this.sessionid)
+    const tokenKey = this._jwtAuth ? 'jwt_token' : 'token'
+    const { project, token } = this.options
+    const bc = new Connect({ project, [tokenKey]: token }, this.sessionid)
     const response = await this.execute(bc).catch(this._handleLoginError)
     if (response) {
       this._autoReconnect = true

--- a/packages/common/src/messages/blade/Connect.ts
+++ b/packages/common/src/messages/blade/Connect.ts
@@ -8,7 +8,7 @@ const revision = 0
 class Connect extends BaseMessage {
   method: string = 'blade.connect'
 
-  constructor(authentication: { project: string, token: string }, sessionid?: string) {
+  constructor(authentication: { project: string, token?: string, jwt_token?: string }, sessionid?: string) {
     super()
 
     const params: IBladeConnectRequest['params'] = {

--- a/packages/common/tests/messages.test.ts
+++ b/packages/common/tests/messages.test.ts
@@ -3,15 +3,22 @@ import { Login, Invite, Answer, Bye, Modify, Info, Result } from '../src/message
 
 describe('Messages', function () {
   describe('BladeConnect', function () {
+    const auth = { project: 'project', token: 'token' }
     it('should match struct without sessionId', function () {
-      const message = new Connect({ project: 'project', token: 'token' }).request
+      const message = new Connect(auth).request
       const res = JSON.parse(`{"jsonrpc":"2.0","id":"${message.id}","method":"blade.connect","params":{"authentication":{"project":"project","token":"token"},"version":{"major":2,"minor":1,"revision":0}}}`)
       expect(message).toEqual(res)
     })
     it('should match struct with sessionId', function () {
       const sessionId = '5c26c8d1-adcc-4b46-aa32-d9550022fddc'
-      const message = new Connect({ project: 'project', token: 'token' }, sessionId).request
+      const message = new Connect(auth, sessionId).request
       const res = JSON.parse(`{"jsonrpc":"2.0","id":"${message.id}","method":"blade.connect","params":{"authentication":{"project":"project","token":"token"},"version":{"major":2,"minor":1,"revision":0},"sessionid":"${sessionId}"}}`)
+      expect(message).toEqual(res)
+    })
+    it('should match struct with jwt_token', function () {
+      const jwtAuth = { project: 'project', jwt_token: 'token' }
+      const message = new Connect(jwtAuth).request
+      const res = JSON.parse(`{"jsonrpc":"2.0","id":"${message.id}","method":"blade.connect","params":{"authentication":{"project":"project","jwt_token":"token"},"version":{"major":2,"minor":1,"revision":0}}}`)
       expect(message).toEqual(res)
     })
   })

--- a/packages/web/src/SignalWire.ts
+++ b/packages/web/src/SignalWire.ts
@@ -7,6 +7,8 @@ import { Execute } from '../../common/src/messages/Blade'
 import BaseRequest from '../../common/src/messages/verto/BaseRequest'
 
 export default class SignalWire extends BrowserSession {
+  protected _jwtAuth: boolean = true
+
   execute(message: BaseMessage) {
     let msg: BaseMessage = message
     if (message instanceof BaseRequest) {


### PR DESCRIPTION
Relay web client has `_jwtAuth = true` so it connect using `jwt_token` instead of `token`.

For the end user the properties to init a client will always be `host` / `project` / `token`

#### Web:
```javascript
const client = new Relay({
  host: 'example.signalwire.com',
  project: 'project',
  token: '<JWT>',
})
```


#### Node:
```javascript
const client = new RelayClient({
  host: 'example.signalwire.com',
  project: 'project',
  token: '<SPACE-TOKEN>',
})
```