### PR TITLE
Handle Blade nested response

### DIFF
--- a/packages/common/src/services/Connection.ts
+++ b/packages/common/src/services/Connection.ts
@@ -91,10 +91,11 @@ export default class Connection {
           return reject(error)
         }
         if (result) {
-          const { result: { code = null, result: nestedResult = null } = {} } = result
+          const { result: { code = null, node_id = null, result: nestedResult = null } = {} } = result
           if (code && code !== '200') {
             reject(result)
           } else if (nestedResult) {
+            nestedResult.node_id = node_id
             resolve(nestedResult)
           } else {
             resolve(result)

--- a/packages/common/src/services/Connection.ts
+++ b/packages/common/src/services/Connection.ts
@@ -91,8 +91,14 @@ export default class Connection {
           return reject(error)
         }
         if (result) {
-          const { result: { code = null } = {} } = result
-          code && code !== '200' ? reject(result) : resolve(result)
+          const { result: { code = null, result: nestedResult = null } = {} } = result
+          if (code && code !== '200') {
+            reject(result)
+          } else if (nestedResult) {
+            resolve(nestedResult)
+          } else {
+            resolve(result)
+          }
         }
       })
       this._setTimer(request.id)

--- a/packages/common/src/webrtc/Dialog.ts
+++ b/packages/common/src/webrtc/Dialog.ts
@@ -549,7 +549,7 @@ export default class Dialog {
     }
     this._execute(msg)
       .then(response => {
-        const { result: { node_id = null } = {} } = response
+        const { node_id = null } = response
         this._targetNodeId = node_id
         type === PeerType.Offer ? this.setState(State.Trying) : this.setState(State.Active)
       })

--- a/packages/common/src/webrtc/helpers.ts
+++ b/packages/common/src/webrtc/helpers.ts
@@ -222,7 +222,7 @@ const destructSubscribeResponse = (response: any): DestructuredResult => {
   let wrapper = response
   const { result = null } = response
   if (result) {
-    wrapper = result.result || {}
+    wrapper = result || {}
   }
   Object.keys(tmp).forEach(k => { tmp[k] = wrapper[`${k}Channels`] || [] })
   return tmp


### PR DESCRIPTION
Blade's responses now have a deeper `response` level. If present, Connection will return the nested one instead of the parent.