### PR TITLE
Handle JWT expiration time

### DIFF
--- a/packages/common/src/util/constants/index.ts
+++ b/packages/common/src/util/constants/index.ts
@@ -66,7 +66,8 @@ export const NOTIFICATION_TYPE = {
   conferenceUpdate: 'conferenceUpdate',
   dialogUpdate: 'dialogUpdate',
   vertoClientReady: 'vertoClientReady',
-  userMediaError: 'userMediaError'
+  userMediaError: 'userMediaError',
+  refreshToken: 'refreshToken',
 }
 
 export enum BladeMethod {


### PR DESCRIPTION
Dispatch a notification of type `refreshToken` 1min before the JWT expires so the user can refresh it and update the client.