### PR TITLE
Relay Calling Record

### DIFF
--- a/packages/common/src/relay/calling/Call.ts
+++ b/packages/common/src/relay/calling/Call.ts
@@ -1,14 +1,11 @@
 import { v4 as uuidv4 } from 'uuid'
 import { Execute } from '../../messages/Blade'
 import { deRegister, registerOnce, deRegisterAll } from '../../services/Handler'
-import { CallState, CALL_STATES, DisconnectReason, CallConnectState, CALL_CONNECT_STATES, DEFAULT_CALL_TIMEOUT } from '../../util/constants/relay'
+import { CallState, CALL_STATES, DisconnectReason, CallConnectState, CALL_CONNECT_STATES, DEFAULT_CALL_TIMEOUT, CallNotification } from '../../util/constants/relay'
 import { ICall, ICallOptions, ICallDevice, IMakeCallParams } from '../../util/interfaces'
 // import logger from '../../util/logger'
 import { reduceConnectParams } from '../helpers'
 import Calling from './Calling'
-
-/** This function will check play/collect events too. */
-const _validControlEvents = (event: string): boolean  => /^record./.test(event)
 
 export default class Call implements ICall {
   public id: string
@@ -297,7 +294,7 @@ export default class Call implements ICall {
   }
 
   get recordings(): Object[] {
-    return this._controls.filter(t => t.event_type === 'calling.call.record')
+    return this._controls.filter(t => t.event_type === CallNotification.Record)
   }
 
   get device(): ICallDevice {
@@ -374,7 +371,7 @@ export default class Call implements ICall {
     CALL_STATES.forEach(state => registerOnce(this.id, this._onStateChange.bind(this, state), state))
 
     Object.keys(this._cbQueues)
-      .filter(_validControlEvents)
+      .filter(event => /^record./.test(event))
       .forEach(event => registerOnce(this.id, this._cbQueues[event].bind(this), event))
   }
 

--- a/packages/common/src/relay/calling/Call.ts
+++ b/packages/common/src/relay/calling/Call.ts
@@ -101,6 +101,38 @@ export default class Call implements ICall {
     return this._execute(msg)
   }
 
+  async startRecord(options: any = {}) {
+    this._callIdRequired()
+    const msg = new Execute({
+      protocol: this.relayInstance.protocol,
+      method: 'call.record',
+      params: {
+        node_id: this.nodeId,
+        call_id: this.id,
+        control_id: uuidv4(),
+        type: 'audio',
+        params: options
+      }
+    })
+
+    return this._execute(msg)
+  }
+
+  stopRecord(control_id: string) {
+    this._callIdRequired()
+    const msg = new Execute({
+      protocol: this.relayInstance.protocol,
+      method: 'call.record.stop',
+      params: {
+        node_id: this.nodeId,
+        call_id: this.id,
+        control_id
+      }
+    })
+
+    return this._execute(msg)
+  }
+
   /*
   async join(callsToJoin: Call | Call[]) { // TODO: wip
     this._callIdRequired()

--- a/packages/common/src/relay/calling/Call.ts
+++ b/packages/common/src/relay/calling/Call.ts
@@ -102,7 +102,7 @@ export default class Call implements ICall {
     return this._execute(msg)
   }
 
-  startRecord(options: any = {}) {
+  async startRecord(options: any = {}) {
     this._callIdRequired()
     const msg = new Execute({
       protocol: this.relayInstance.protocol,

--- a/packages/common/src/relay/calling/Call.ts
+++ b/packages/common/src/relay/calling/Call.ts
@@ -276,16 +276,12 @@ export default class Call implements ICall {
     this.options = { ...this.options, ...opts }
   }
 
-  private _getControlIndex(control_id: string): number {
-    return this._controls.findIndex(t => t.control_id === control_id)
-  }
-
   _addControlParams(params: any) {
     const { control_id, event_type } = params
     if (!control_id || !event_type) {
       return
     }
-    const index = this._getControlIndex(control_id)
+    const index = this._controls.findIndex(t => t.control_id === control_id)
     if (index >= 0) {
       this._controls[index] = params
     } else {

--- a/packages/common/src/relay/calling/Calling.ts
+++ b/packages/common/src/relay/calling/Calling.ts
@@ -5,7 +5,7 @@ import { ICallDevice, IMakeCallParams } from '../../util/interfaces'
 import logger from '../../util/logger'
 import Relay from '../Relay'
 import Call from './Call'
-import { DEFAULT_CALL_TIMEOUT } from '../../util/constants/relay'
+import { DEFAULT_CALL_TIMEOUT, CallNotification } from '../../util/constants/relay'
 
 const _ctxUniqueId = (context: string): string => `ctx:${context}`
 
@@ -19,7 +19,7 @@ export default class Calling extends Relay {
   notificationHandler(notification: any) {
     const { event_type, params } = notification
     switch (event_type) {
-      case 'calling.call.state': {
+      case CallNotification.State: {
         const { call_id, node_id, call_state, tag, peer } = params
         let call = this.getCallById(call_id)
         if (call) {
@@ -39,12 +39,12 @@ export default class Calling extends Relay {
         logger.error('\t - Unknown call:', params, '\n\n')
         break
       }
-      case 'calling.call.receive': {
+      case CallNotification.Receive: {
         const call = new Call(this, params)
         trigger(this.protocol, call, _ctxUniqueId(call.context))
         break
       }
-      case 'calling.call.connect': {
+      case CallNotification.Connect: {
         const { call_id, connect_state, peer } = params
         const call = this.getCallById(call_id)
         if (!call) {
@@ -57,7 +57,7 @@ export default class Calling extends Relay {
         trigger(call_id, call, connect_state)
         break
       }
-      case 'calling.call.record': {
+      case CallNotification.Record: {
         const { call_id, state } = params
         const call = this.getCallById(call_id)
         if (!call) {

--- a/packages/common/src/relay/calling/Calling.ts
+++ b/packages/common/src/relay/calling/Calling.ts
@@ -57,6 +57,18 @@ export default class Calling extends Relay {
         trigger(call_id, call, connect_state)
         break
       }
+      case 'calling.call.record': {
+        const { call_id, state } = params
+        const call = this.getCallById(call_id)
+        if (!call) {
+          logger.error('Unknown call:', params)
+          return
+        }
+        params.event_type = event_type
+        call._addControlParams(params)
+        trigger(call_id, params, `record.${state}`)
+        break
+      }
     }
   }
 

--- a/packages/common/src/services/Handler.ts
+++ b/packages/common/src/services/Handler.ts
@@ -34,6 +34,7 @@ const register = (eventName: string, callback: Function, uniqueId: string = GLOB
  * Subscribes the callback to the passed eventName only once. Use uniqueId to render unique the event.
  */
 const registerOnce = (eventName: string, callback: Function, uniqueId: string = GLOBAL) => {
+  /* tslint:disable-next-line */
   const cb = function(data) {
     deRegister(eventName, cb, uniqueId)
     callback(data)
@@ -53,7 +54,7 @@ const deRegister = (eventName: string, callback?: Function | null, uniqueId: str
     const len = queue[eventName][uniqueId].length
     for (let i = len - 1; i >= 0; i--) {
       const fn = queue[eventName][uniqueId][i]
-      if (callback === fn || callback === fn.prototype.targetRef) {
+      if (callback === fn || (fn.prototype && callback === fn.prototype.targetRef)) {
         queue[eventName][uniqueId].splice(i, 1)
       }
     }

--- a/packages/common/src/services/Handler.ts
+++ b/packages/common/src/services/Handler.ts
@@ -34,7 +34,7 @@ const register = (eventName: string, callback: Function, uniqueId: string = GLOB
  * Subscribes the callback to the passed eventName only once. Use uniqueId to render unique the event.
  */
 const registerOnce = (eventName: string, callback: Function, uniqueId: string = GLOBAL) => {
-  const cb = data => {
+  const cb = function(data) {
     deRegister(eventName, cb, uniqueId)
     callback(data)
   }

--- a/packages/common/src/util/constants/relay.ts
+++ b/packages/common/src/util/constants/relay.ts
@@ -39,4 +39,11 @@ export enum CallConnectState {
   failed
 }
 
+export enum CallNotification {
+  State = 'calling.call.state',
+  Receive = 'calling.call.receive',
+  Connect = 'calling.call.connect',
+  Record = 'calling.call.record'
+}
+
 export const CALL_CONNECT_STATES = Object.keys(CallConnectState).filter(k => isNaN(Number(k)))

--- a/packages/common/tests/behaveLike/BaseSession.ts
+++ b/packages/common/tests/behaveLike/BaseSession.ts
@@ -147,11 +147,6 @@ export default (instance: any) => {
     describe('static methods', () => {
       const mockFn = jest.fn()
 
-      it('.uuid() should returns UUID v4', () => {
-        const pattern = new RegExp(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i)
-        expect(BaseSession.uuid()).toMatch(pattern)
-      })
-
       it('.on() should add a listener into the internal queue', () => {
         BaseSession.on('event', mockFn)
         expect(isQueued('event')).toEqual(true)

--- a/packages/common/tests/setup/connection.ts
+++ b/packages/common/tests/setup/connection.ts
@@ -1,2 +1,9 @@
 const Connection = require('../../src/services/Connection')
 jest.mock('../../src/services/Connection')
+
+
+jest.mock('uuid', () => {
+  return {
+    v4: jest.fn(() => 'mocked-uuid')
+  };
+});

--- a/packages/node/examples/calling/index.js
+++ b/packages/node/examples/calling/index.js
@@ -79,6 +79,19 @@ async function createCall(to) {
     console.log(`\t ${call.id} failed to connect!`, '\n')
   })
 
+  leg.on('record.recording', params => {
+    console.log(`\t Record state changed for ${params.call_id} in ${params.state} - ${params.control_id}`)
+  })
+  leg.on('record.paused', params => {
+    console.log(`\t Record state changed for ${params.call_id} in ${params.state} - ${params.control_id}`)
+  })
+  leg.on('record.finished', params => {
+    console.log(`\t Record state changed for ${params.call_id} in ${params.state} - ${params.control_id}`)
+  })
+  leg.on('record.no_input', params => {
+    console.log(`\t Record state changed for ${params.call_id} in ${params.state} - ${params.control_id}`)
+  })
+
   return leg
 }
 
@@ -184,6 +197,28 @@ function _init() {
           })
         })
       }
+
+      if (true) { // TODO:
+        call.on('answered', call => {
+          const recordOpts = {
+            beep: false,
+            format: 'mp3',
+            stereo: false,
+            direction: 'both',
+            // initial_timeout: 0.0,
+            // end_silence_timeout: 0.0,
+            // terminators: ''
+          }
+          call.startRecord(recordOpts)
+            .then(response => {
+              console.log(`\t Record Success!`, response)
+            })
+            .catch(error => {
+              console.error(`\t Record failed?`, error)
+            })
+        })
+      }
+
       console.warn(`\tCall to ${answers.to_number} starts now!\n`)
       call.begin()
         .catch(error => {

--- a/packages/node/tests/relay/Call.test.ts
+++ b/packages/node/tests/relay/Call.test.ts
@@ -210,7 +210,7 @@ describe('Call', () => {
         expect(Connection.mockSend).toHaveBeenCalledTimes(1)
         const msg = new Execute({
           protocol: 'signalwire_service_random_uuid',
-          method: 'call.record',
+          method: 'call.record.stop',
           params: {
             node_id: undefined,
             call_id: call.id,

--- a/packages/node/tests/relay/Call.test.ts
+++ b/packages/node/tests/relay/Call.test.ts
@@ -32,6 +32,7 @@ describe('Call', () => {
   describe('creating outbound calls', () => {
     let call: Call = null
     beforeEach(() => {
+      Connection.mockSend.mockClear()
       mockSetupResponses()
       session.calling.addCall = jest.fn()
       const device: ICallDevice = { type: 'phone', params: { from_number: '2345', to_number: '6789', timeout: 30 } }
@@ -177,7 +178,6 @@ describe('Call', () => {
       })
 
       it('should execute the right message', () => {
-        Connection.mockSend.mockClear()
         const opts = { format: 'mp3', beep: true }
         call.startRecord(opts)
         expect(Connection.mockSend).toHaveBeenCalledTimes(1)
@@ -190,6 +190,31 @@ describe('Call', () => {
             control_id: 'mocked-uuid',
             type: 'audio',
             params: opts
+          }
+        })
+        expect(Connection.mockSend).toHaveBeenCalledWith(msg)
+      })
+    })
+
+    describe('.stopRecord()', () => {
+      beforeEach(() => {
+        call.id = 'testing-on-method'
+      })
+
+      afterEach(() => {
+        call.id = undefined
+      })
+
+      it('should execute the right message', () => {
+        call.stopRecord('control-id')
+        expect(Connection.mockSend).toHaveBeenCalledTimes(1)
+        const msg = new Execute({
+          protocol: 'signalwire_service_random_uuid',
+          method: 'call.record',
+          params: {
+            node_id: undefined,
+            call_id: call.id,
+            control_id: 'control-id'
           }
         })
         expect(Connection.mockSend).toHaveBeenCalledWith(msg)


### PR DESCRIPTION
This PR add the chance to register listeners for `recording` notification and two methods to start/stop the recording of the Call.

#### startRecord()
```javascript
const leg = await client.calling.newCall({ type: 'phone', from: '123', to: '456' })

leg.on('record.recording', params => {
  console.log(`Record started for ${params.call_id} in ${params.state} - ${params.control_id}`)
})
leg.on('record.paused', params => {
  console.log(`Record paused for ${params.call_id} in ${params.state} - ${params.control_id}`)
})
leg.on('record.finished', params => {
  console.log(`Record finished for ${params.call_id} in ${params.state} - ${params.control_id}`)
})
leg.on('record.no_input', params => {
  console.log(`Record no_input for ${params.call_id} in ${params.state} - ${params.control_id}`)
})


call.on('answered', call => {
  const recordOpts = {
    beep: false,
    format: 'mp3',
    stereo: false,
    direction: 'both',
    // initial_timeout: 0.0,
    // end_silence_timeout: 0.0,
    // terminators: ''
  }
  call.startRecord(recordOpts)
    .then(response => {
      console.log(`Record Success!`, response)
    })
    .catch(error => {
      console.error(`Record failed?`, error)
    })
})

call.begin()
```

I add the prefix `record.` to the notification name to scope it and avoid to overlap other notifications.

#### .recordings
The user can also inspect the `recordings` (there may be many) with the getter:

```javascript
const recs = leg.recordings // Returns an array
```

#### stopRecord()
The user has to take `control_id` from the notification and use it in `stopRecord`.
```javascript
  call.stopRecord('<CONTROL-ID>')
```