### PR TITLE
Fix/cache after transfer

### DIFF
--- a/packages/common/src/webrtc/Dialog.ts
+++ b/packages/common/src/webrtc/Dialog.ts
@@ -302,8 +302,10 @@ export default class Dialog {
         const { eventData: data } = params
         switch (data.contentType) {
           case 'layout-info':
-            const tmp = JSON.stringify(data.canvasInfo).replace(/ID"/g, 'Id"').replace(/POS"/g, 'Pos"')
-            this._dispatchConferenceUpdate({ action: ConferenceAction.LayoutInfo, data: JSON.parse(tmp) })
+            if (typeof data.canvasInfo === 'object') {
+              const tmp = JSON.stringify(data.canvasInfo).replace(/ID"/g, 'Id"').replace(/POS"/g, 'Pos"')
+              this._dispatchConferenceUpdate({ action: ConferenceAction.LayoutInfo, data: JSON.parse(tmp) })
+            }
             break
           default:
             logger.error('Conference-Info unknown contentType', params)

--- a/packages/common/src/webrtc/VertoHandler.ts
+++ b/packages/common/src/webrtc/VertoHandler.ts
@@ -150,14 +150,18 @@ class VertoHandler {
         // trigger Notification at a Dialog or Session level.
         // deregister Notification callback at the Dialog level.
         // Cleanup subscriptions for all channels
+        let dialog: Dialog = null
         if (laChannel && session._existsSubscription(protocol, laChannel)) {
           const { dialogId = null } = session.subscriptions[protocol][laChannel]
+          dialog = session.dialogs[dialogId] || null
           if (dialogId !== null) {
             const notification = { type: NOTIFICATION_TYPE.conferenceUpdate, action: ConferenceAction.Leave, conferenceName: laName, participantId: Number(conferenceMemberID), role }
             if (!trigger(SwEvent.Notification, notification, dialogId, false)) {
               trigger(SwEvent.Notification, notification, session.uuid)
             }
-            deRegister(SwEvent.Notification, null, dialogId)
+            if (dialog === null) {
+              deRegister(SwEvent.Notification, null, dialogId)
+            }
           }
         }
         session.vertoUnsubscribe({ nodeId: this.nodeId, channels: [laChannel, chatChannel, infoChannel, modChannel] })

--- a/packages/common/src/webrtc/VertoHandler.ts
+++ b/packages/common/src/webrtc/VertoHandler.ts
@@ -164,7 +164,16 @@ class VertoHandler {
             }
           }
         }
-        session.vertoUnsubscribe({ nodeId: this.nodeId, channels: [laChannel, chatChannel, infoChannel, modChannel] })
+        const channels = [laChannel, chatChannel, infoChannel, modChannel]
+        session.vertoUnsubscribe({ nodeId: this.nodeId, channels })
+          .then(({ unsubscribedChannels }) => {
+            if (dialog) {
+              dialog.channels = dialog.channels.filter(c => !unsubscribedChannels.includes(c))
+            }
+          })
+          .catch(error => {
+            logger.error('liveArray unsubscribe error:', error)
+          })
         break
       }
     }


### PR DESCRIPTION
This PR includes:

- prevent an error if `layout-info` comes without `canvasInfo`.
- update internal array `dialog.channels` after transfer.
