### PR TITLE
PlayX action objects

### DIFF
--- a/packages/common/src/relay/calling/Actions.ts
+++ b/packages/common/src/relay/calling/Actions.ts
@@ -1,0 +1,39 @@
+import { Execute } from '../../messages/Blade'
+import Call from './Call'
+
+abstract class BaseAction {
+
+  protected abstract baseMethod: string
+
+  constructor(public call: Call, protected controlId: string) {}
+
+  stop() {
+    const msg = new Execute({
+      protocol: this.call.relayInstance.protocol,
+      method: `${this.baseMethod}.stop`,
+      params: {
+        node_id: this.call.nodeId,
+        call_id: this.call.id,
+        control_id: this.controlId
+      }
+    })
+
+    return this.call._execute(msg)
+  }
+}
+
+class PlayAction extends BaseAction {
+  protected baseMethod = 'call.play'
+}
+
+class PlayMediaAction extends PlayAction {}
+class PlayAudioAction extends PlayAction {}
+class PlaySilenceAction extends PlayAction {}
+class PlayTTSAction extends PlayAction {}
+
+export {
+  PlayMediaAction,
+  PlayAudioAction,
+  PlaySilenceAction,
+  PlayTTSAction
+}

--- a/packages/common/src/relay/calling/Call.ts
+++ b/packages/common/src/relay/calling/Call.ts
@@ -18,7 +18,7 @@ export default class Call implements ICall {
   private _cbQueue: { [state: string]: Function } = {}
   private _controls: any[] = []
 
-  constructor(protected relayInstance: Calling, protected options: ICallOptions) {
+  constructor(public relayInstance: Calling, protected options: ICallOptions) {
     const { call_id, node_id } = options
     this.id = call_id
     this.nodeId = node_id
@@ -417,7 +417,7 @@ export default class Call implements ICall {
     }
   }
 
-  private async _execute(msg: Execute) {
+  public async _execute(msg: Execute) {
     try {
       const { result } = await this.relayInstance.session.execute(msg)
       return result

--- a/packages/common/src/relay/calling/Calling.ts
+++ b/packages/common/src/relay/calling/Calling.ts
@@ -105,7 +105,7 @@ export default class Calling extends Relay {
     } else if (call_id && peer) {
       const peerCall = new Call(this, params)
     } else {
-      logger.error('\t - Unknown call:', params, '\n\n')
+      logger.debug('\t - Unknown call:', params, '\n\n')
     }
   }
 

--- a/packages/node/tests/relay/Actions.test.ts
+++ b/packages/node/tests/relay/Actions.test.ts
@@ -1,0 +1,106 @@
+import Call from '../../../common/src/relay/calling/Call'
+import { Execute } from '../../../common/src/messages/Blade'
+import { PlayMediaAction, PlayAudioAction, PlaySilenceAction, PlayTTSAction } from '../../../common/src/relay/calling/Actions'
+import RelayClient from '../../src/relay'
+
+const Connection = require('../../../common/src/services/Connection')
+
+describe('Calling', () => {
+  const _mockConnection = () => {
+    Connection.mockResponse
+      .mockReturnValueOnce(JSON.parse('{"id":"c04d725a-c8bc-4b9e-bf1e-9c05150797cc","jsonrpc":"2.0","result":{"requester_nodeid":"05b1114c-XXXX-YYYY-ZZZZ-feaa30afad6c","responder_nodeid":"9811eb32-XXXX-YYYY-ZZZZ-ab56fa3b83c9","result":{"protocol":"signalwire_service_random_uuid"}}}'))
+      .mockReturnValueOnce(JSON.parse('{"id":"24f9b545-8bed-49e1-8214-5dbadb545f7d","jsonrpc":"2.0","result":{"command":"add","failed_channels":[],"protocol":"signalwire_service_random_uuid","subscribe_channels":["notifications"]}}'))
+  }
+  let session: RelayClient = null
+  let call: Call = null
+
+  beforeAll(async done => {
+    session = new RelayClient({ host: 'example.signalwire.com', project: 'project', token: 'token' })
+    await session.connect()
+    _mockConnection()
+    call = await session.calling.newCall({ type: 'phone', from: '234', to: '567' })
+    call.id = 'call-id'
+    call.nodeId = 'node-id'
+    done()
+  })
+
+  beforeEach(() => {
+    Connection.mockSend.mockClear()
+  })
+
+  describe('PlayMediaAction', () => {
+    it('should stop the current media in play', async done => {
+      const action = new PlayMediaAction(call, 'control-id')
+      await action.stop()
+      const msg = new Execute({
+        protocol: 'signalwire_service_random_uuid',
+        method: 'call.play.stop',
+        params: {
+          node_id: 'node-id',
+          call_id: 'call-id',
+          control_id: 'control-id'
+        }
+      })
+      expect(Connection.mockSend).toHaveBeenCalledTimes(1)
+      expect(Connection.mockSend).toHaveBeenCalledWith(msg)
+      done()
+    })
+  })
+
+  describe('PlayAudioAction', () => {
+    it('should stop the current media in play', async done => {
+      const action = new PlayAudioAction(call, 'control-id')
+      await action.stop()
+      const msg = new Execute({
+        protocol: 'signalwire_service_random_uuid',
+        method: 'call.play.stop',
+        params: {
+          node_id: 'node-id',
+          call_id: 'call-id',
+          control_id: 'control-id'
+        }
+      })
+      expect(Connection.mockSend).toHaveBeenCalledTimes(1)
+      expect(Connection.mockSend).toHaveBeenCalledWith(msg)
+      done()
+    })
+  })
+
+  describe('PlaySilenceAction', () => {
+    it('should stop the current media in play', async done => {
+      const action = new PlaySilenceAction(call, 'control-id')
+      await action.stop()
+      const msg = new Execute({
+        protocol: 'signalwire_service_random_uuid',
+        method: 'call.play.stop',
+        params: {
+          node_id: 'node-id',
+          call_id: 'call-id',
+          control_id: 'control-id'
+        }
+      })
+      expect(Connection.mockSend).toHaveBeenCalledTimes(1)
+      expect(Connection.mockSend).toHaveBeenCalledWith(msg)
+      done()
+    })
+  })
+
+  describe('PlayTTSAction', () => {
+    it('should stop the current media in play', async done => {
+      const action = new PlayTTSAction(call, 'control-id')
+      await action.stop()
+      const msg = new Execute({
+        protocol: 'signalwire_service_random_uuid',
+        method: 'call.play.stop',
+        params: {
+          node_id: 'node-id',
+          call_id: 'call-id',
+          control_id: 'control-id'
+        }
+      })
+      expect(Connection.mockSend).toHaveBeenCalledTimes(1)
+      expect(Connection.mockSend).toHaveBeenCalledWith(msg)
+      done()
+    })
+  })
+})


### PR DESCRIPTION
- Remove `stoPlay()` method
- Create new objects that will be returned by the same _playX_ method: `PlayMediaAction` - `PlayAudioAction` - `PlaySilenceAction` - `PlayTTSAction`.

All new objects expose a `.stop()` method to stop the current media in playing.