### PR TITLE
Detect socket close

### DIFF
--- a/packages/common/src/BaseSession.ts
+++ b/packages/common/src/BaseSession.ts
@@ -133,8 +133,6 @@ export default abstract class BaseSession {
    * @return void
    */
   async disconnect() {
-    logger.warn('disconnect')
-    trigger(SwEvent.Disconnect, null, this.uuid, false)
     this._destroyRelayInstances()
     await this._unsubscribeAll()
     this.subscriptions = {}

--- a/packages/common/src/BrowserSession.ts
+++ b/packages/common/src/BrowserSession.ts
@@ -53,14 +53,13 @@ export default abstract class BrowserSession extends BaseSession {
   }
 
   /**
-   * Purge all active dialogs
-   * @return void
+   * Disconnect all active dialogs
    */
-  purge() {
+  async disconnect() {
     Object.keys(this.dialogs).forEach(k => this.dialogs[k].setState(State.Purge))
     this.dialogs = {}
 
-    super.purge()
+    await super.disconnect()
   }
 
   speedTest(bytes: number) {

--- a/packages/common/src/relay/Relay.ts
+++ b/packages/common/src/relay/Relay.ts
@@ -1,8 +1,7 @@
 import BaseSession from '../BaseSession'
 import { Execute } from '../messages/Blade'
 import { Setup } from '../services/Setup'
-import { registerOnce, deRegisterAll } from '../services/Handler'
-import { SwEvent } from '../util/constants'
+import { deRegisterAll } from '../services/Handler'
 
 abstract class Relay {
   [x: string]: any
@@ -26,20 +25,18 @@ abstract class Relay {
         console.error(error)
       }
     })
+  }
 
-    registerOnce(SwEvent.Disconnect, this._disconnect.bind(this), this.session.uuid)
+  destroy() {
+    if (this.protocol) {
+      deRegisterAll(this.protocol)
+    }
   }
 
   protected async configure() {
     const { resource, domain } = this.session.options
     const msg = new Execute({ protocol: this.protocol, method: 'configure', params: { resource, domain } })
     await this.session.execute(msg)
-  }
-
-  protected _disconnect() {
-    if (this.protocol) {
-      deRegisterAll(this.protocol)
-    }
   }
 }
 

--- a/packages/common/src/relay/calling/Calling.ts
+++ b/packages/common/src/relay/calling/Calling.ts
@@ -79,15 +79,6 @@ export default class Calling extends Relay {
     return this._calls.find(call => call.tag === tag)
   }
 
-  protected _disconnect() {
-    this._calls.forEach(call => {
-      if (call.ready) {
-        call.hangup().catch(logger.warn)
-      }
-    })
-    super._disconnect()
-  }
-
   /**
    * Handle calling.call.state notification params
    * @param params - Inner params of calling.call.state notification

--- a/packages/common/src/services/Connection.ts
+++ b/packages/common/src/services/Connection.ts
@@ -3,6 +3,7 @@ import BaseSession from '../BaseSession'
 import { SwEvent } from '../util/constants'
 import { safeParseJson, checkWebSocketHost } from '../util/helpers'
 import { registerOnce, trigger } from '../services/Handler'
+import { isFunction } from '../util/helpers'
 
 let WebSocketClass: any = typeof WebSocket !== 'undefined' ? WebSocket : null
 export const setWebSocket = (websocket: any): void => {
@@ -15,13 +16,14 @@ const WS_STATE = {
   CLOSING: 2,
   CLOSED: 3
 }
-
+const PING_INTERVAL = 5 * 1000
 const REQUEST_TIMEOUT = 10 * 1000
 
 export default class Connection {
   private _wsClient: any = null
   private _host: string = 'wss://localhost:2100'
   private _timers: { [id: string]: any } = {}
+  private _connected: boolean = false
 
   public upDur: number = null
   public downDur: number = null
@@ -57,7 +59,11 @@ export default class Connection {
 
   connect() {
     this._wsClient = new WebSocketClass(this._host)
-    this._wsClient.onopen = (event): boolean => trigger(SwEvent.SocketOpen, event, this.session.uuid)
+    this._wsClient.onopen = (event): boolean => {
+      this._connected = true
+      this._ping()
+      return trigger(SwEvent.SocketOpen, event, this.session.uuid)
+    }
     this._wsClient.onclose = (event): boolean => trigger(SwEvent.SocketClose, event, this.session.uuid)
     this._wsClient.onerror = (event): boolean => trigger(SwEvent.SocketError, event, this.session.uuid)
     this._wsClient.onmessage = (event): void => {
@@ -142,5 +148,18 @@ export default class Connection {
     } else {
       logger.warn('Unknown message from socket', response)
     }
+  }
+
+  private _ping() {
+    if (!this._wsClient || !this._wsClient.ping) {
+      return
+    }
+    if (this._connected) {
+      this._connected = false
+      this._wsClient.ping('', () => this._connected = true)
+      return setTimeout(() => this._ping(), PING_INTERVAL)
+    }
+    const { _beginClose, close } = this._wsClient
+    isFunction(_beginClose) ? _beginClose() : close()
   }
 }

--- a/packages/common/src/util/constants/index.ts
+++ b/packages/common/src/util/constants/index.ts
@@ -16,7 +16,6 @@ export enum SwEvent {
 
   // Internal events
   SpeedTest = 'signalwire.internal.speedtest',
-  Disconnect = 'signalwire.internal.disconnect',
   Connect = 'signalwire.internal.connect',
 
   // Global Events

--- a/packages/common/tests/behaveLike/BaseSession.ts
+++ b/packages/common/tests/behaveLike/BaseSession.ts
@@ -79,7 +79,16 @@ export default (instance: any) => {
       describe('subscribe', () => { })
       describe('unsubscribe', () => { })
       describe('broadcast', () => { })
-      describe('disconnect', () => { })
+
+      describe('.disconnect()', () => {
+        it('should close the connection', async done => {
+          await instance.disconnect()
+          expect(Connection.mockClose).toHaveBeenCalled()
+          expect(instance.dialogs).toMatchObject({})
+          expect(instance.subscriptions).toMatchObject({})
+          done()
+        })
+      })
     })
 
     describe('protected methods', () => {

--- a/packages/common/tests/behaveLike/BaseSession.ts
+++ b/packages/common/tests/behaveLike/BaseSession.ts
@@ -84,7 +84,7 @@ export default (instance: any) => {
         it('should close the connection', async done => {
           await instance.disconnect()
           expect(Connection.mockClose).toHaveBeenCalled()
-          expect(instance.dialogs).toMatchObject({})
+          expect(instance.dialogs || {}).toMatchObject({})
           expect(instance.subscriptions).toMatchObject({})
           done()
         })

--- a/packages/common/tests/behaveLike/BaseSession.ts
+++ b/packages/common/tests/behaveLike/BaseSession.ts
@@ -4,20 +4,22 @@ const Connection = require('../../src/services/Connection')
 
 export default (instance: any) => {
   describe('Inherit BaseClass', () => {
-    afterEach(() => {
-      instance.disconnect()
+
+    beforeEach(async done => {
+      await instance.connect()
       instance._idle = false
+      instance._executeQueue = []
+      instance.subscriptions = {}
       Connection.mockSend.mockClear()
       Connection.mockSendRawText.mockClear()
+      done()
     })
 
     describe('public methods', () => {
-      // TODO: implement all these specs
       describe('execute', () => {
         const payload = { request: { fake: 'data' } }
 
         it('should send the message through the socket if the connection is live', async done => {
-          await instance.connect()
           const response = await instance.execute(payload)
           expect(Connection.mockSend).toHaveBeenLastCalledWith(payload)
           expect(response).toEqual('fake')
@@ -25,6 +27,7 @@ export default (instance: any) => {
         })
 
         it('should queue the message if the connection went down', async done => {
+          await instance.disconnect()
           instance.execute(payload)
             .then(response => {
               expect(instance.connected).toEqual(true)
@@ -34,6 +37,7 @@ export default (instance: any) => {
           expect(Connection.mockSend).not.toHaveBeenCalled()
           expect(instance._executeQueue).toHaveLength(1)
           await instance.connect()
+          instance._idle = false
           instance._emptyExecuteQueues()
         })
 

--- a/packages/web/tests/Verto.test.ts
+++ b/packages/web/tests/Verto.test.ts
@@ -77,15 +77,6 @@ describe('Verto', () => {
     })
   })
 
-  describe('.disconnect()', () => {
-    it('should close the connection', () => {
-      instance.disconnect()
-      expect(Connection.mockClose).toHaveBeenCalled()
-      expect(instance.dialogs).toMatchObject({})
-      expect(instance.subscriptions).toMatchObject({})
-    })
-  })
-
   describe('.speedTest()', () => {
     // TODO:
   })


### PR DESCRIPTION
Check socket connection with ping/pong keepalive and improved disconnect/socket close behaviour.

Currently, if i want to disconnect my client, all relay calls will stay up. `Graceful` vs `Forced` disconnect is out of scope here.