### PR TITLE
WebRTC device/resolutions improvements

### DIFF
--- a/packages/common/src/BrowserSession.ts
+++ b/packages/common/src/BrowserSession.ts
@@ -30,6 +30,9 @@ export default abstract class BrowserSession extends BaseSession {
     this.connection = new Connection(this)
   }
 
+  /**
+   * Check if the browser has the permission to access mic and/or webcam
+   */
   async checkPermissions(audio: boolean = true, video: boolean = true): Promise<boolean> {
     try {
       const stream = await getUserMedia({ audio, video })
@@ -85,6 +88,9 @@ export default abstract class BrowserSession extends BaseSession {
     })
   }
 
+  /**
+   * Refresh the device list doing an enumerateDevices
+   */
   async refreshDevices() {
     this._devices = await getDevices()
     return this.devices
@@ -94,6 +100,9 @@ export default abstract class BrowserSession extends BaseSession {
     return this._devices
   }
 
+  /**
+   * Return supported resolution for the given webcam.
+   */
   async getDeviceResolutions(deviceId: string) {
     try {
       return await scanResolutions(deviceId)

--- a/packages/common/src/BrowserSession.ts
+++ b/packages/common/src/BrowserSession.ts
@@ -1,14 +1,15 @@
 import BaseSession from './BaseSession'
 import Connection from './services/Connection'
 import Dialog from './webrtc/Dialog'
-import { ICacheDevices, IAudioSettings, IVideoSettings, BroadcastParams, SubscribeParams, ICacheResolution } from './util/interfaces'
-import { trigger, registerOnce } from './services/Handler'
-import { SwEvent, NOTIFICATION_TYPE, SESSION_ID } from './util/constants'
+import { ICacheDevices, IAudioSettings, IVideoSettings, BroadcastParams, SubscribeParams } from './util/interfaces'
+import { registerOnce } from './services/Handler'
+import { SwEvent, SESSION_ID } from './util/constants'
 import { State } from './util/constants/dialog'
-import { getDevices, getResolutions, checkPermissions, removeUnsupportedConstraints, checkDeviceIdConstraints, destructSubscribeResponse } from './webrtc/helpers'
+import { getDevices, scanResolutions, removeUnsupportedConstraints, checkDeviceIdConstraints, destructSubscribeResponse, getUserMedia } from './webrtc/helpers'
 import { findElementByType } from './util/helpers'
 import { Unsubscribe, Subscribe, Broadcast } from './messages/Verto'
 import * as Storage from './util/storage/'
+import { stopStream } from './util/webrtc'
 
 export default abstract class BrowserSession extends BaseSession {
   public dialogs: { [dialogId: string]: Dialog } = {}
@@ -20,20 +21,23 @@ export default abstract class BrowserSession extends BaseSession {
   protected _devices: ICacheDevices = {}
   protected _audioConstraints: boolean | MediaTrackConstraints = true
   protected _videoConstraints: boolean | MediaTrackConstraints = false
-  protected _resolutions: ICacheResolution[]
 
   async connect(): Promise<void> {
     super.setup()
 
-    const success = await checkPermissions()
-    if (success) {
-      this.refreshResolutions()
-    } else {
-      trigger(SwEvent.Notification, { type: NOTIFICATION_TYPE.userMediaError, error: 'Permission denied' }, this.uuid)
-    }
     await this.refreshDevices()
     this.sessionid = await Storage.getItem(SESSION_ID)
     this.connection = new Connection(this)
+  }
+
+  async checkPermissions(audio: boolean = true, video: boolean = true): Promise<boolean> {
+    try {
+      const stream = await getUserMedia({ audio, video })
+      stopStream(stream)
+      return true
+    } catch {
+      return false
+    }
   }
 
   /**
@@ -90,18 +94,12 @@ export default abstract class BrowserSession extends BaseSession {
     return this._devices
   }
 
-  async refreshResolutions() {
-    this._resolutions = await getResolutions()
-    return this.resolutions
-  }
-
-  get resolutions() {
-    return this._resolutions
-  }
-
-  /** Backwards compatibility */
-  supportedResolutions() {
-    return Promise.resolve(this.resolutions)
+  async getDeviceResolutions(deviceId: string) {
+    try {
+      return await scanResolutions(deviceId)
+    } catch (error) {
+      throw error
+    }
   }
 
   get videoDevices() {

--- a/packages/common/src/util/interfaces.ts
+++ b/packages/common/src/util/interfaces.ts
@@ -129,10 +129,6 @@ export interface ICacheDevices {
   audiooutput?: { [deviceId: string]: MediaDeviceInfo }
 }
 
-export interface ICacheResolution extends MediaTrackSettings {
-  resolution: string
-}
-
 export interface IAudioSettings extends MediaTrackConstraints {
   micId: string
   micLabel: string

--- a/packages/common/src/webrtc/helpers.ts
+++ b/packages/common/src/webrtc/helpers.ts
@@ -121,19 +121,6 @@ const assureDeviceId = async (id: string, label: string, kind: MediaDeviceInfo['
   return null
 }
 
-const checkPermissions = async (constraints: MediaStreamConstraints = { audio: true, video: true }): Promise<boolean> => {
-  try {
-    const stream = await getUserMedia(constraints)
-    stopStream(stream)
-    return true
-  } catch {
-    if (constraints.video) {
-      return await checkPermissions({ audio: true })
-    }
-  }
-  return false
-}
-
 const removeUnsupportedConstraints = (constraints: MediaTrackConstraints): void => {
   const supported = WebRTC.getSupportedConstraints()
   Object.keys(constraints).map(key => {
@@ -242,7 +229,6 @@ export {
   getResolutions,
   getMediaConstraints,
   assureDeviceId,
-  checkPermissions,
   removeUnsupportedConstraints,
   checkDeviceIdConstraints,
   sdpStereoHack,


### PR DESCRIPTION
Stop check perms and scan resolutions when client connects.

Add `checkPermissions()` and `getDeviceResolutions(deviceId)` methods to do that.