### PR TITLE
WebRTC Call local device methods

### DIFF
--- a/packages/common/src/BrowserSession.ts
+++ b/packages/common/src/BrowserSession.ts
@@ -21,6 +21,7 @@ export default abstract class BrowserSession extends BaseSession {
   protected _devices: ICacheDevices = {}
   protected _audioConstraints: boolean | MediaTrackConstraints = true
   protected _videoConstraints: boolean | MediaTrackConstraints = false
+  protected _speaker: string = null
 
   async connect(): Promise<void> {
     super.setup()
@@ -167,6 +168,19 @@ export default abstract class BrowserSession extends BaseSession {
 
   get iceServers() {
     return this._iceServers
+  }
+
+  set speaker(deviceId: string) {
+    const knownSpeakers = Object.keys(this.audioOutDevices)
+    if (knownSpeakers.includes(deviceId)) {
+      this._speaker = deviceId
+    } else {
+      throw new Error(`Unknown device ${deviceId}.`)
+    }
+  }
+
+  get speaker() {
+    return this._speaker
   }
 
   set localElement(tag: HTMLMediaElement | string | Function) {

--- a/packages/common/src/services/Connection.ts
+++ b/packages/common/src/services/Connection.ts
@@ -21,7 +21,7 @@ const REQUEST_TIMEOUT = 10 * 1000
 
 export default class Connection {
   private _wsClient: any = null
-  private _host: string = 'wss://relay.swire.io'
+  private _host: string = 'wss://relay.signalwire.com'
   private _timers: { [id: string]: any } = {}
   private _connected: boolean = false
 

--- a/packages/common/src/services/Connection.ts
+++ b/packages/common/src/services/Connection.ts
@@ -21,7 +21,7 @@ const REQUEST_TIMEOUT = 10 * 1000
 
 export default class Connection {
   private _wsClient: any = null
-  private _host: string = 'wss://relay.signalwire.com'
+  private _host: string = 'wss://relay.swire.io'
   private _timers: { [id: string]: any } = {}
   private _connected: boolean = false
 

--- a/packages/common/src/util/webrtc/index.native.ts
+++ b/packages/common/src/util/webrtc/index.native.ts
@@ -23,6 +23,10 @@ const detachMediaStream = (htmlElementId: string) => null
 const muteMediaElement = (htmlElementId: string) => null
 const unmuteMediaElement = (htmlElementId: string) => null
 
+const setMediaElementSinkId = async (htmlElementId: string, deviceId: string) => {
+  throw new Error('setSinkId: Not supported.')
+}
+
 const sdpToJsonHack = sdp => {
   Object.defineProperty(sdp, 'toJSON', { value: () => sdp })
   return sdp
@@ -47,5 +51,6 @@ export {
   sdpToJsonHack,
   stopStream,
   muteMediaElement,
-  unmuteMediaElement
+  unmuteMediaElement,
+  setMediaElementSinkId
 }

--- a/packages/common/src/util/webrtc/index.native.ts
+++ b/packages/common/src/util/webrtc/index.native.ts
@@ -20,6 +20,9 @@ const getSupportedConstraints = () => ({})
 const attachMediaStream = (htmlElementId: string, stream: MediaStream) => null
 const detachMediaStream = (htmlElementId: string) => null
 
+const muteMediaElement = (htmlElementId: string) => null
+const unmuteMediaElement = (htmlElementId: string) => null
+
 const sdpToJsonHack = sdp => {
   Object.defineProperty(sdp, 'toJSON', { value: () => sdp })
   return sdp
@@ -42,5 +45,7 @@ export {
   attachMediaStream,
   detachMediaStream,
   sdpToJsonHack,
-  stopStream
+  stopStream,
+  muteMediaElement,
+  unmuteMediaElement
 }

--- a/packages/common/src/util/webrtc/index.native.ts
+++ b/packages/common/src/util/webrtc/index.native.ts
@@ -23,9 +23,7 @@ const detachMediaStream = (htmlElementId: string) => null
 const muteMediaElement = (htmlElementId: string) => null
 const unmuteMediaElement = (htmlElementId: string) => null
 
-const setMediaElementSinkId = async (htmlElementId: string, deviceId: string) => {
-  throw new Error('setSinkId: Not supported.')
-}
+const setMediaElementSinkId = (htmlElementId: string, deviceId: string): Promise<boolean> => Promise.resolve(false)
 
 const sdpToJsonHack = sdp => {
   Object.defineProperty(sdp, 'toJSON', { value: () => sdp })

--- a/packages/common/src/util/webrtc/index.ts
+++ b/packages/common/src/util/webrtc/index.ts
@@ -48,18 +48,28 @@ const unmuteMediaElement = (tag: any) => {
   }
 }
 
-const setMediaElementSinkId = async (tag: any, deviceId: string) => {
+const setMediaElementSinkId = async (tag: any, deviceId: string): Promise<boolean> => {
   const element: HTMLMediaElement = findElementByType(tag)
-  if (element) {
-    // @ts-ignore
-    if (!element.setSinkId) {
-      throw new Error('HTMLMediaElement setSinkId - Not supported.')
-    }
-    // @ts-ignore
-    await element.setSinkId(deviceId).catch((error: DOMException) => {
-      throw new Error('HTMLMediaElement setSinkId - No permission to use the requested device.')
-    })
+  if (element === null) {
+    return false
   }
+  try {
+    // @ts-ignore
+    await element.setSinkId(deviceId)
+    return true
+  } catch (error) {
+    return false
+  }
+  // if (element) {
+  //   // @ts-ignore
+  //   if (!element.setSinkId) {
+  //     throw new Error('HTMLMediaElement setSinkId - Not supported.')
+  //   }
+  //   // @ts-ignore
+  //   await element.setSinkId(deviceId).catch((error: DOMException) => {
+  //     throw new Error('HTMLMediaElement setSinkId - No permission to use the requested device.')
+  //   })
+  // }
 }
 
 const sdpToJsonHack = sdp => sdp

--- a/packages/common/src/util/webrtc/index.ts
+++ b/packages/common/src/util/webrtc/index.ts
@@ -60,16 +60,6 @@ const setMediaElementSinkId = async (tag: any, deviceId: string): Promise<boolea
   } catch (error) {
     return false
   }
-  // if (element) {
-  //   // @ts-ignore
-  //   if (!element.setSinkId) {
-  //     throw new Error('HTMLMediaElement setSinkId - Not supported.')
-  //   }
-  //   // @ts-ignore
-  //   await element.setSinkId(deviceId).catch((error: DOMException) => {
-  //     throw new Error('HTMLMediaElement setSinkId - No permission to use the requested device.')
-  //   })
-  // }
 }
 
 const sdpToJsonHack = sdp => sdp

--- a/packages/common/src/util/webrtc/index.ts
+++ b/packages/common/src/util/webrtc/index.ts
@@ -34,6 +34,20 @@ const detachMediaStream = (tag: any) => {
   }
 }
 
+const muteMediaElement = (tag: any) => {
+  const element = findElementByType(tag)
+  if (element) {
+    element.muted = true
+  }
+}
+
+const unmuteMediaElement = (tag: any) => {
+  const element = findElementByType(tag)
+  if (element) {
+    element.muted = false
+  }
+}
+
 const sdpToJsonHack = sdp => sdp
 
 const stopStream = (stream: MediaStream) => {
@@ -53,5 +67,7 @@ export {
   attachMediaStream,
   detachMediaStream,
   sdpToJsonHack,
-  stopStream
+  stopStream,
+  muteMediaElement,
+  unmuteMediaElement
 }

--- a/packages/common/src/util/webrtc/index.ts
+++ b/packages/common/src/util/webrtc/index.ts
@@ -48,6 +48,20 @@ const unmuteMediaElement = (tag: any) => {
   }
 }
 
+const setMediaElementSinkId = async (tag: any, deviceId: string) => {
+  const element: HTMLMediaElement = findElementByType(tag)
+  if (element) {
+    // @ts-ignore
+    if (!element.setSinkId) {
+      throw new Error('HTMLMediaElement setSinkId - Not supported.')
+    }
+    // @ts-ignore
+    await element.setSinkId(deviceId).catch((error: DOMException) => {
+      throw new Error('HTMLMediaElement setSinkId - No permission to use the requested device.')
+    })
+  }
+}
+
 const sdpToJsonHack = sdp => sdp
 
 const stopStream = (stream: MediaStream) => {
@@ -69,5 +83,6 @@ export {
   sdpToJsonHack,
   stopStream,
   muteMediaElement,
-  unmuteMediaElement
+  unmuteMediaElement,
+  setMediaElementSinkId
 }

--- a/packages/common/src/webrtc/Call.ts
+++ b/packages/common/src/webrtc/Call.ts
@@ -225,6 +225,14 @@ export default class Call {
       },
       unmute: () => {
         this._confControl(this.memberChannel, { action: 'undeaf' })
+      },
+      changeDevice: async (deviceId: string): Promise<boolean> => {
+        this.options.speakerId = deviceId
+        const { remoteElement, speakerId } = this.options
+        if (remoteElement && speakerId) {
+          return setMediaElementSinkId(remoteElement, speakerId)
+        }
+        return false
       }
     }
   }
@@ -246,9 +254,7 @@ export default class Call {
         setTimeout(() => {
           const { remoteElement, speakerId } = this.options
           if (remoteElement && speakerId) {
-            setMediaElementSinkId(remoteElement, speakerId).catch(error => {
-              trigger(SwEvent.Error, error, this.session.uuid)
-            })
+            setMediaElementSinkId(remoteElement, speakerId)
           }
         }, 0)
         break

--- a/packages/common/src/webrtc/Call.ts
+++ b/packages/common/src/webrtc/Call.ts
@@ -10,7 +10,7 @@ import { trigger, register, deRegister } from '../services/Handler'
 import { sdpStereoHack, sdpMediaOrderHack, checkSubscribeResponse } from './helpers'
 import { objEmpty, mutateLiveArrayData, isFunction } from '../util/helpers'
 import { CallOptions } from '../util/interfaces'
-import { attachMediaStream, detachMediaStream, sdpToJsonHack, stopStream, getDisplayMedia, setMediaElementSinkId } from '../util/webrtc'
+import { attachMediaStream, detachMediaStream, sdpToJsonHack, stopStream, getDisplayMedia, setMediaElementSinkId, muteMediaElement, unmuteMediaElement } from '../util/webrtc'
 
 export default class Call {
   public id: string = ''
@@ -192,39 +192,29 @@ export default class Call {
 
   get microphone() {
     return {
-      mute: () => {
-        this._confControl(this.memberChannel, { action: 'mute' })
-      },
-      unmute: () => {
-        this._confControl(this.memberChannel, { action: 'unmute' })
-      },
-      toggleMute: () => {
-        this._confControl(this.memberChannel, { action: 'tmute' })
-      }
+      mute: () => this.peer.audioState = 'off',
+      unmute: () => this.peer.audioState = 'on',
+      toggleMute: () => this.peer.audioState = 'toggle'
     }
   }
 
   get webcam() {
     return {
-      mute: () => {
-        this._confControl(this.memberChannel, { action: 'vmute' })
-      },
-      unmute: () => {
-        this._confControl(this.memberChannel, { action: 'unvmute' })
-      },
-      toggleMute: () => {
-        this._confControl(this.memberChannel, { action: 'tvmute' })
-      }
+      mute: () => this.peer.videoState = 'off',
+      unmute: () => this.peer.videoState = 'on',
+      toggleMute: () => this.peer.videoState = 'toggle'
     }
   }
 
   get speaker() {
     return {
       mute: () => {
-        this._confControl(this.memberChannel, { action: 'deaf' })
+        const { remoteElement } = this.options
+        muteMediaElement(remoteElement)
       },
       unmute: () => {
-        this._confControl(this.memberChannel, { action: 'undeaf' })
+        const { remoteElement } = this.options
+        unmuteMediaElement(remoteElement)
       },
       changeDevice: async (deviceId: string): Promise<boolean> => {
         this.options.speakerId = deviceId

--- a/packages/common/src/webrtc/Peer.ts
+++ b/packages/common/src/webrtc/Peer.ts
@@ -1,7 +1,7 @@
 import logger from '../util/logger'
 import { getUserMedia, getMediaConstraints, sdpStereoHack } from './helpers'
 import { PeerType, SwEvent } from '../util/constants'
-import { attachMediaStream, sdpToJsonHack, RTCPeerConnection, streamIsValid } from '../util/webrtc'
+import { attachMediaStream, muteMediaElement, sdpToJsonHack, RTCPeerConnection, streamIsValid } from '../util/webrtc'
 import { isFunction } from '../util/helpers'
 import { CallOptions } from '../util/interfaces'
 import { trigger } from '../services/Handler'
@@ -86,6 +86,7 @@ export default class Peer {
         this.instance.addStream(localStream)
       }
       if (screenShare !== true) {
+        muteMediaElement(localElement)
         attachMediaStream(localElement, localStream)
       }
     } else if (localStream === null) {


### PR DESCRIPTION
Mute/Unmute mic/cam/speakers instead of using Conference methods (call 1:1).

Select default speaker at the Client level.