### PR TITLE
Add support for sessionStorage

### DIFF
--- a/packages/common/src/BaseSession.ts
+++ b/packages/common/src/BaseSession.ts
@@ -4,13 +4,12 @@ import Connection from './services/Connection'
 import BaseMessage from '../../common/src/messages/BaseMessage'
 import { deRegister, register, trigger, deRegisterAll } from './services/Handler'
 import { BroadcastHandler } from './services/Broadcast'
-import { ADD, REMOVE, SwEvent, BladeMethod, NOTIFICATION_TYPE, SESSION_ID } from './util/constants'
+import { ADD, REMOVE, SwEvent, BladeMethod, NOTIFICATION_TYPE } from './util/constants'
 import Cache from './util/Cache'
 import { BroadcastParams, ISignalWireOptions, SubscribeParams, Constructable } from './util/interfaces'
 import { Subscription, Connect, Reauthenticate } from './messages/Blade'
 import { isFunction } from './util/helpers'
 import Relay from './relay/Relay'
-import * as Storage from './util/storage/'
 
 export default abstract class BaseSession {
   public uuid: string = uuidv4()
@@ -141,7 +140,6 @@ export default abstract class BaseSession {
     this._removeConnection()
     this._executeQueue = []
     this._detachListeners()
-    await Storage.removeItem(SESSION_ID)
   }
 
   /**
@@ -238,7 +236,6 @@ export default abstract class BaseSession {
       this.master_nodeid = master_nodeid
       this._cache = new Cache()
       this._cache.populateFromConnect(response)
-      Storage.setItem(SESSION_ID, this.sessionid)
       trigger(SwEvent.Connect, null, this.uuid, false)
       this._emptyExecuteQueues()
       trigger(SwEvent.Ready, this, this.uuid)

--- a/packages/common/src/BrowserSession.ts
+++ b/packages/common/src/BrowserSession.ts
@@ -8,7 +8,7 @@ import { State } from './util/constants/call'
 import { getDevices, scanResolutions, removeUnsupportedConstraints, checkDeviceIdConstraints, destructSubscribeResponse, getUserMedia } from './webrtc/helpers'
 import { findElementByType } from './util/helpers'
 import { Unsubscribe, Subscribe, Broadcast } from './messages/Verto'
-import * as Storage from './util/storage/'
+import { localStorage } from './util/storage/'
 import { stopStream } from './util/webrtc'
 
 export default abstract class BrowserSession extends BaseSession {
@@ -27,7 +27,7 @@ export default abstract class BrowserSession extends BaseSession {
     super.setup()
 
     await this.refreshDevices()
-    this.sessionid = await Storage.getItem(SESSION_ID)
+    this.sessionid = await localStorage.getItem(SESSION_ID)
     this.connection = new Connection(this)
   }
 

--- a/packages/common/src/services/Setup.ts
+++ b/packages/common/src/services/Setup.ts
@@ -1,6 +1,6 @@
 import BaseSession from '../BaseSession'
 import { Execute } from '../messages/Blade'
-import * as Storage from '../util/storage/'
+import { sessionStorage } from '../util/storage/'
 
 const SETUP_PROTOCOL = 'signalwire'
 const SETUP_METHOD = 'setup'
@@ -10,7 +10,7 @@ export const Setup = async (session: BaseSession, service: string, handler?: Fun
   const { project } = session.options
   const params: { service: string, protocol?: string } = { service }
   const _key = `${project}-${service}`
-  const currentProtocol = await Storage.getItem(_key)
+  const currentProtocol = await sessionStorage.getItem(_key)
   if (currentProtocol) {
     params.protocol = currentProtocol
   }
@@ -18,6 +18,6 @@ export const Setup = async (session: BaseSession, service: string, handler?: Fun
   const { result: { protocol = null } = {} } = await session.execute(be)
   await session.subscribe({ protocol, channels: [SETUP_CHANNEL], handler })
 
-  await Storage.setItem(_key, protocol)
+  await sessionStorage.setItem(_key, protocol)
   return protocol
 }

--- a/packages/common/src/util/storage/index.native.ts
+++ b/packages/common/src/util/storage/index.native.ts
@@ -1,15 +1,14 @@
 // @ts-ignore
 import { AsyncStorage } from 'react-native'
 import { mutateStorageKey, safeParseJson } from '../helpers'
-import logger from '../logger'
 
 const getItem = async (key: string): Promise<any> => {
-  const res = await AsyncStorage.getItem(mutateStorageKey(key))
-    .catch(error => {
-      logger.debug('AsyncStorage.getItem error', error)
-      return ''
-    })
-  return safeParseJson(res)
+  try {
+    const res = await AsyncStorage.getItem(mutateStorageKey(key))
+    return safeParseJson(res)
+  } catch (error) {
+    return null
+  }
 }
 
 const setItem = (key: string, value: any): Promise<void> => {
@@ -21,8 +20,5 @@ const setItem = (key: string, value: any): Promise<void> => {
 
 const removeItem = (key: string): Promise<void> => AsyncStorage.removeItem(mutateStorageKey(key))
 
-export {
-  getItem,
-  setItem,
-  removeItem
-}
+export const localStorage = { getItem, setItem, removeItem }
+export const sessionStorage = { getItem, setItem, removeItem }

--- a/packages/common/src/util/storage/index.ts
+++ b/packages/common/src/util/storage/index.ts
@@ -2,33 +2,36 @@ import { mutateStorageKey, safeParseJson } from '../helpers'
 
 const _inNode = () => typeof window === 'undefined' && typeof process !== 'undefined'
 
-const getItem = async (key: string): Promise<any> => {
-  if (_inNode()) {
-    return null
-  }
-  const res = window.localStorage.getItem(mutateStorageKey(key))
+const _get = async (storageType: string, key: string): Promise<any> => {
+  if (_inNode()) return null
+
+  const res = window[storageType].getItem(mutateStorageKey(key))
   return safeParseJson(res)
 }
 
-const setItem = async (key: string, value: any): Promise<void> => {
-  if (_inNode()) {
-    return null
-  }
+const _set = async (storageType: string, key: string, value: any): Promise<void> => {
+  if (_inNode()) return null
+
   if (typeof value === 'object') {
     value = JSON.stringify(value)
   }
-  window.localStorage.setItem(mutateStorageKey(key), value)
+  window[storageType].setItem(mutateStorageKey(key), value)
 }
 
-const removeItem = async (key: string): Promise<void> => {
-  if (_inNode()) {
-    return null
-  }
-  return window.localStorage.removeItem(mutateStorageKey(key))
+const _remove = async (storageType: string, key: string): Promise<void> => {
+  if (_inNode()) return null
+
+  return window[storageType].removeItem(mutateStorageKey(key))
 }
 
-export {
-  getItem,
-  setItem,
-  removeItem
+export const localStorage = {
+  getItem: (key: string): Promise<any> => _get('localStorage', key),
+  setItem: (key: string, value: any): Promise<void> => _set('localStorage', key, value),
+  removeItem: (key: string): Promise<void> => _remove('localStorage', key),
+}
+
+export const sessionStorage = {
+  getItem: (key: string): Promise<any> => _get('sessionStorage', key),
+  setItem: (key: string, value: any): Promise<void> => _set('sessionStorage', key, value),
+  removeItem: (key: string): Promise<void> => _remove('sessionStorage', key),
 }

--- a/packages/common/src/webrtc/helpers.ts
+++ b/packages/common/src/webrtc/helpers.ts
@@ -1,5 +1,5 @@
 import logger from '../util/logger'
-import * as Storage from '../util/storage'
+import { localStorage } from '../util/storage'
 import * as WebRTC from '../util/webrtc'
 import { isDefined } from '../util/helpers'
 import { CallOptions, ICacheDevices } from '../util/interfaces'
@@ -50,7 +50,7 @@ const getDevices = async (): Promise<ICacheDevices> => {
 const resolutionList = [[320, 240], [640, 360], [640, 480], [1280, 720], [1920, 1080]]
 const scanResolutions = async (deviceId: string) => {
   const storageKey = `${deviceId}-resolutions`
-  const supported = (await Storage.getItem(storageKey)) || []
+  const supported = (await localStorage.getItem(storageKey)) || []
   if (supported && supported.length) {
     return supported
   }
@@ -67,7 +67,7 @@ const scanResolutions = async (deviceId: string) => {
   }
   stopStream(stream)
 
-  Storage.setItem(storageKey, supported)
+  localStorage.setItem(storageKey, supported)
 
   return supported
 }

--- a/packages/common/src/webrtc/helpers.ts
+++ b/packages/common/src/webrtc/helpers.ts
@@ -44,7 +44,6 @@ const getDevices = async (): Promise<ICacheDevices> => {
   } catch (error) {
     logger.error('enumerateDevices Error', error)
   }
-  Storage.setItem('devices', cache)
   return cache
 }
 

--- a/packages/common/tests/setup/browsers.ts
+++ b/packages/common/tests/setup/browsers.ts
@@ -1,44 +1,21 @@
 import * as webrtcMocks from './webrtcMocks'
-const localStorageMock = (() => {
-  let store = {}
-  return {
-    getItem: (key: string) => {
-      return store[key] || null
-    },
-    setItem: (key: string, value: any) => {
-      store[key] = value.toString()
-    },
-    removeItem: (key: string) => {
-      delete store[key]
-    },
-    clear: () => {
-      store = {}
-    }
-  }
-})()
 
-if (typeof window === 'undefined') {
-  // @ts-ignore
-  global.window = {}
-}
-
-Object.defineProperties(window, {
-  localStorage: {
-    value: localStorageMock
-  },
-  RTCPeerConnection: {
-    value: () => {
-      return {
-        close: () => { },
-        addTrack: () => { },
-        createOffer: () => { },
-        createAnswer: () => { },
-        setLocalDescription: () => { },
-        setRemoteDescription: () => { },
+if (typeof window !== 'undefined') {
+  Object.defineProperties(window, {
+    RTCPeerConnection: {
+      value: () => {
+        return {
+          close: () => { },
+          addTrack: () => { },
+          createOffer: () => { },
+          createAnswer: () => { },
+          setLocalDescription: () => { },
+          setRemoteDescription: () => { },
+        }
       }
     }
-  }
-})
+  })
+}
 
 if (typeof MediaStream === 'undefined') {
   // @ts-ignore

--- a/packages/js/src/Verto.ts
+++ b/packages/js/src/Verto.ts
@@ -4,7 +4,7 @@ import { Login } from '../../common/src/messages/Verto'
 import Call from '../../common/src/webrtc/Call'
 import { SwEvent, SESSION_ID } from '../../common/src/util/constants'
 import { trigger } from '../../common/src/services/Handler'
-import * as Storage from '../../common/src/util/storage/'
+import { localStorage } from '../../common/src/util/storage/'
 import VertoHandler from '../../common/src/webrtc/VertoHandler'
 
 export const VERTO_PROTOCOL = 'verto-protocol'
@@ -42,7 +42,7 @@ export default class Verto extends BrowserSession {
     const response = await this.execute(msg).catch(this._handleLoginError)
     if (response) {
       this.sessionid = response.sessid
-      Storage.setItem(SESSION_ID, this.sessionid)
+      localStorage.setItem(SESSION_ID, this.sessionid)
       trigger(SwEvent.Ready, this, this.uuid)
     }
   }

--- a/tslint.json
+++ b/tslint.json
@@ -3,7 +3,10 @@
     "class-name": true,
     "only-arrow-functions": true,
     "ban-comma-operator": true,
-    "curly": true,
+    "curly": [
+      true,
+      "ignore-same-line"
+    ],
     "no-bitwise": true,
     "no-conditional-assignment": true,
     "no-duplicate-super": true,


### PR DESCRIPTION
- Support for both session and local storage.
- Proxy methods to prevent error in Node and use AsyncStorage in ReactNative.
- Protocols in `sessionStorage` instead of `localStorage`
- Jest and Lint improvements