### PR TITLE
call.receive with multiple contexts

### DIFF
--- a/packages/common/src/BaseSession.ts
+++ b/packages/common/src/BaseSession.ts
@@ -226,6 +226,7 @@ export default abstract class BaseSession {
       this.master_nodeid = master_nodeid
       this._emptyExecuteQueues()
       trigger(SwEvent.Ready, this, this.uuid)
+      logger.info('Session Ready!')
     }
   }
 


### PR DESCRIPTION
Force calling.onInbound to send `contexts` as an array of strings and simplify RelayConsumer code