### PR TITLE
Release JS package v1.1.2

### DIFF
--- a/packages/common/src/BaseSession.ts
+++ b/packages/common/src/BaseSession.ts
@@ -23,10 +23,10 @@ export default abstract class BaseSession {
   protected connection: Connection = null
   protected _jwtAuth: boolean = false
   protected _reconnectDelay: number = 5000
+  protected _autoReconnect: boolean = false
 
   private _idle: boolean = false
   private _executeQueue: { resolve?: Function, msg: any}[] = []
-  private _autoReconnect: boolean = false
 
   constructor(public options: ISignalWireOptions) {
     if (!this.validateOptions()) {

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -27,6 +27,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Security
 - Update dependencies
 
+## [1.1.2] - 2019-07-17
+### Fixed
+- Fix reconnection logic on Verto client.
+
 ## [1.1.1] - 2019-06-26
 ### Fixed
 - Update Call.localStream if microphone or webcam has changed.

--- a/packages/js/package-lock.json
+++ b/packages/js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalwire/js",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalwire/js",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Relay SDK for JavaScript to connect to SignalWire.",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "main": "dist/index.min.js",

--- a/packages/js/src/Verto.ts
+++ b/packages/js/src/Verto.ts
@@ -44,6 +44,7 @@ export default class Verto extends BrowserSession {
     const msg = new Login(login, (password || passwd), this.sessionid, userVariables)
     const response = await this.execute(msg).catch(this._handleLoginError)
     if (response) {
+      this._autoReconnect = true
       this.sessionid = response.sessid
       localStorage.setItem(SESSION_ID, this.sessionid)
       trigger(SwEvent.Ready, this, this.uuid)

--- a/packages/js/webpack.config.js
+++ b/packages/js/webpack.config.js
@@ -1,4 +1,5 @@
 const webpack = require('webpack')
+const VERSION = require('./package.json').version
 
 module.exports = (env, argv) => {
   const outputDir = __dirname + '/dist'
@@ -40,6 +41,9 @@ module.exports = (env, argv) => {
         'process.env': {
           NODE_ENV: mode,
         }
+      }),
+      new webpack.BannerPlugin({
+        banner: `Relay SDK for JavaScript v${VERSION} (https://signalwire.com)\nCopyright 2018-2019 SignalWire\nLicensed under MIT(https://github.com/signalwire/signalwire-node/blob/master/LICENSE)`
       })
     ]
   }


### PR DESCRIPTION
Verto standalone had an override of the "socket open" method where i missed to set a flag to `true`.