### PR TITLE
Relay Calling Tap

### DIFF
--- a/packages/common/src/relay/calling/Call.ts
+++ b/packages/common/src/relay/calling/Call.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid'
 import logger from '../../util/logger'
 import { Execute } from '../../messages/Blade'
 import { CallState, DisconnectReason, DEFAULT_CALL_TIMEOUT, CallNotification, CallRecordState, CallPlayState, CallPromptState, CallConnectState, CALL_STATES, CallFaxState, CallDetectState, CallDetectType, CallTapState } from '../../util/constants/relay'
-import { ICall, ICallOptions, ICallDevice, IMakeCallParams, ICallingPlay, ICallingCollect, DeepArray, ICallingDetect, ICallingTapTap, ICallingTapDevice } from '../../util/interfaces'
+import { ICall, ICallOptions, ICallDevice, IMakeCallParams, ICallingPlay, ICallingCollect, DeepArray, ICallingDetect, ICallingTapTapArg, ICallingTapDeviceArg } from '../../util/interfaces'
 import { reduceConnectParams } from '../helpers'
 import Calling from './Calling'
 import { isFunction } from '../../util/helpers'
@@ -419,16 +419,20 @@ export default class Call implements ICall {
     return this.detectAsync(CallDetectType.Digit, params, timeout)
   }
 
-  async tap(tap: ICallingTapTap, device: ICallingTapDevice): Promise<TapResult> {
-    const component = new Tap(this, tap, device)
+  async tap(tap: ICallingTapTapArg, device: ICallingTapDeviceArg): Promise<TapResult> {
+    const { type: tapType, ...tapParams } = tap
+    const { type: deviceType, ...deviceParams } = device
+    const component = new Tap(this, { type: tapType, params: tapParams }, { type: deviceType, params: deviceParams })
     this._addComponent(component)
     await component._waitFor(CallTapState.Finished)
 
     return new TapResult(component)
   }
 
-  async tapAsync(tap: ICallingTapTap, device: ICallingTapDevice): Promise<TapAction> {
-    const component = new Tap(this, tap, device)
+  async tapAsync(tap: ICallingTapTapArg, device: ICallingTapDeviceArg): Promise<TapAction> {
+    const { type: tapType, ...tapParams } = tap
+    const { type: deviceType, ...deviceParams } = device
+    const component = new Tap(this, { type: tapType, params: tapParams }, { type: deviceType, params: deviceParams })
     this._addComponent(component)
     await component.execute()
 

--- a/packages/common/src/relay/calling/Calling.ts
+++ b/packages/common/src/relay/calling/Calling.ts
@@ -32,6 +32,8 @@ export default class Calling extends Relay {
         return this._onFax(params)
       case CallNotification.Detect:
         return this._onDetect(params)
+      case CallNotification.Tap:
+        return this._onTap(params)
     }
   }
 
@@ -199,6 +201,18 @@ export default class Calling extends Relay {
     const call = this.getCallById(params.call_id)
     if (call) {
       call._detectChange(params)
+    }
+  }
+
+  /**
+   * Handle calling.call.tap notification params
+   * @param params - Inner params of calling.call.tap notification
+   * @return void
+   */
+  private _onTap(params: any): void {
+    const call = this.getCallById(params.call_id)
+    if (call) {
+      call._tapChange(params)
     }
   }
 }

--- a/packages/common/src/relay/calling/actions/TapAction.ts
+++ b/packages/common/src/relay/calling/actions/TapAction.ts
@@ -1,0 +1,23 @@
+import BaseAction from './BaseAction'
+import Tap from '../components/Tap'
+import TapResult from '../results/TapResult'
+import { ICallingTapDevice } from '../../../util/interfaces'
+
+export default class TapAction extends BaseAction {
+
+  constructor(public component: Tap) {
+    super(component)
+  }
+
+  get result(): TapResult {
+    return new TapResult(this.component)
+  }
+
+  get sourceDevice(): ICallingTapDevice {
+    return this.component.sourceDevice
+  }
+
+  stop() {
+    return this.component.stop()
+  }
+}

--- a/packages/common/src/relay/calling/components/Tap.ts
+++ b/packages/common/src/relay/calling/components/Tap.ts
@@ -1,0 +1,53 @@
+import Controllable from './Controllable'
+import { ICallingTapTap, ICallingTapDevice } from '../../../util/interfaces'
+import { CallNotification, CallTapState } from '../../../util/constants/relay'
+import Call from '../Call'
+import Event from '../Event'
+
+export default class Tap extends Controllable {
+  public eventType: string = CallNotification.Tap
+  public controlId: string = this.controlId
+
+  constructor(public call: Call, public tap: ICallingTapTap, public device: ICallingTapDevice) {
+    super(call)
+  }
+
+  get method(): string {
+    return 'call.tap'
+  }
+
+  get payload(): any {
+    return {
+      node_id: this.call.nodeId,
+      call_id: this.call.id,
+      control_id: this.controlId,
+      tap: this.tap,
+      device: this.device
+    }
+  }
+
+  get sourceDevice(): ICallingTapDevice {
+    if (!this._executeResult) {
+      return null
+    }
+    const { source_device = null } = this._executeResult
+    return source_device
+  }
+
+  notificationHandler(params: any): void {
+    const { state, tap, device } = params
+    this.tap = tap
+    this.device = device
+    this.state = state
+
+    this.completed = this.state === CallTapState.Finished
+    if (this.completed) {
+      this.successful = true
+      this.event = new Event(this.state, params)
+    }
+
+    if (this._hasBlocker() && this._eventsToWait.includes(this.state)) {
+      this.blocker.resolve()
+    }
+  }
+}

--- a/packages/common/src/relay/calling/results/TapResult.ts
+++ b/packages/common/src/relay/calling/results/TapResult.ts
@@ -1,0 +1,21 @@
+import BaseResult from './BaseResult'
+import Tap from '../components/Tap'
+import { ICallingTapTap, ICallingTapDevice } from '../../../util/interfaces'
+
+export default class TapResult extends BaseResult {
+  constructor(public component: Tap) {
+    super(component)
+  }
+
+  get tap(): ICallingTapTap {
+    return this.component.tap
+  }
+
+  get sourceDevice(): ICallingTapDevice {
+    return this.component.sourceDevice
+  }
+
+  get destinationDevice(): ICallingTapDevice {
+    return this.component.device
+  }
+}

--- a/packages/common/src/services/BroadcastHandler.ts
+++ b/packages/common/src/services/BroadcastHandler.ts
@@ -28,6 +28,7 @@ export default function BroadcastHandler(session: any, broadcastParams: any): vo
       case CallNotification.Collect:
       case CallNotification.Fax:
       case CallNotification.Detect:
+      case CallNotification.Tap:
         session.calling.notificationHandler(params)
         break
       case 'webrtc.message':

--- a/packages/common/src/util/constants/relay.ts
+++ b/packages/common/src/util/constants/relay.ts
@@ -49,11 +49,17 @@ export enum CallNotification {
   Collect = 'calling.call.collect',
   Fax = 'calling.call.fax',
   Detect = 'calling.call.detect',
+  Tap = 'calling.call.tap',
 }
 
 export enum CallPlayState {
   Playing = 'playing',
   Error = 'error',
+  Finished = 'finished',
+}
+
+export enum CallTapState {
+  Tapping = 'tapping',
   Finished = 'finished',
 }
 

--- a/packages/common/src/util/interfaces.ts
+++ b/packages/common/src/util/interfaces.ts
@@ -242,6 +242,25 @@ export interface ICallingDetect {
   timeout?: number
 }
 
+export interface ICallingTapTap {
+  type: 'audio'
+  params: {
+    direction?: string
+  }
+}
+
+export interface ICallingTapDevice {
+  type: 'rtp' | 'ws'
+  params: {
+    addr?: string
+    port?: number
+    codec?: string
+    ptime?: number
+    uri?: string
+    rate?: number
+  }
+}
+
 export interface DeepArray<T> extends Array<T | DeepArray<T>> { }
 
 export interface IRelayConsumerParams {

--- a/packages/common/src/util/interfaces.ts
+++ b/packages/common/src/util/interfaces.ts
@@ -242,23 +242,35 @@ export interface ICallingDetect {
   timeout?: number
 }
 
+export interface ICallingTapTapParams {
+  direction?: string
+}
+
 export interface ICallingTapTap {
   type: 'audio'
-  params: {
-    direction?: string
-  }
+  params: ICallingTapTapParams
+}
+
+export interface ICallingTapTapArg extends ICallingTapTapParams {
+  type: ICallingTapTap['type']
+}
+
+interface ICallingTapDeviceParams {
+  addr?: string
+  port?: number
+  codec?: string
+  ptime?: number
+  uri?: string
+  rate?: number
 }
 
 export interface ICallingTapDevice {
   type: 'rtp' | 'ws'
-  params: {
-    addr?: string
-    port?: number
-    codec?: string
-    ptime?: number
-    uri?: string
-    rate?: number
-  }
+  params: ICallingTapDeviceParams
+}
+
+export interface ICallingTapDeviceArg extends ICallingTapDeviceParams {
+  type: ICallingTapDevice['type']
 }
 
 export interface DeepArray<T> extends Array<T | DeepArray<T>> { }

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Create your own Relay Tasks and enable `onTask` method on RelayConsumer to receive/handle them.
 - Methods to start a detector on a Call: `detect`, `detectAsync`, `detectHuman`, `detectHumanAsync`, `detectMachine`, `detectMachineAsync`, `detectFax`, `detectFaxAsync`, `detectDigit`, `detectDigitAsync`
+- Methods to tap media in a Call: `tap` and `tapAsync`
 
 ## [2.0.0] - 2019-07-16
 ### Added

--- a/packages/node/tests/relay/Call.test.ts
+++ b/packages/node/tests/relay/Call.test.ts
@@ -705,11 +705,11 @@ describe('Call', () => {
       beforeEach(() => {
         Connection.mockResponse() // Consume mock request because TAP has a different resposnse
         const response = JSON.parse('{"id":"uuid","jsonrpc":"2.0","result":{"result":{"code":"200","message":"message","control_id":"control-id"}}}')
-        response.result.result.source_device = sourceCevice
+        response.result.result.source_device = sourceService
         Connection.mockResponse.mockReturnValueOnce(response)
       })
 
-      const sourceCevice: ICallingTapDevice = { type: 'rtp', params: { addr: '10.10.10.10', port: 3000, codec: 'PCMU', rate: 8000 } }
+      const sourceService: ICallingTapDevice = { type: 'rtp', params: { addr: '10.10.10.10', port: 3000, codec: 'PCMU', rate: 8000 } }
       const tap: ICallingTapTap = { type: 'audio', params: { direction: 'listen' } }
       const device: ICallingTapDevice = { type: 'rtp', params: { addr: '127.0.0.1', port: 1234 } }
       const getMsg = () => new Execute({
@@ -722,7 +722,7 @@ describe('Call', () => {
         call.tap(tap, device).then(result => {
           expect(result).toBeInstanceOf(TapResult)
           expect(result.successful).toBe(true)
-          expect(result.sourceDevice).toEqual(sourceCevice)
+          expect(result.sourceDevice).toEqual(sourceService)
           expect(result.destinationDevice).toEqual({ type: 'rtp', params: { addr: '127.0.0.1', port: '1234', codec: 'PCMU', ptime: '20' } })
           expect(Connection.mockSend).nthCalledWith(1, getMsg())
           done()

--- a/packages/node/tests/relay/Call.test.ts
+++ b/packages/node/tests/relay/Call.test.ts
@@ -1117,7 +1117,7 @@ describe('Call', () => {
         })
       })
 
-      it('.recordAsync() should return a TapAction for async control', async done => {
+      it('.tapAsync() should return a TapAction for async control', async done => {
         const action = await call.tapAsync(tap, device)
         expect(action).toBeInstanceOf(TapAction)
         expect(action.completed).toBe(true)

--- a/packages/node/tests/relay/Call.test.ts
+++ b/packages/node/tests/relay/Call.test.ts
@@ -1,5 +1,5 @@
 import RelayClient from '../../src/relay'
-import { ICallDevice, ICallingPlay, ICallingTapTap, ICallingTapDevice } from '../../../common/src/util/interfaces'
+import { ICallDevice, ICallingPlay, ICallingTapDevice, ICallingTapTapArg, ICallingTapDeviceArg } from '../../../common/src/util/interfaces'
 import Call from '../../../common/src/relay/calling/Call'
 import { CallState } from '../../../common/src/util/constants/relay'
 import { Execute } from '../../../common/src/messages/Blade'
@@ -710,12 +710,14 @@ describe('Call', () => {
       })
 
       const sourceService: ICallingTapDevice = { type: 'rtp', params: { addr: '10.10.10.10', port: 3000, codec: 'PCMU', rate: 8000 } }
-      const tap: ICallingTapTap = { type: 'audio', params: { direction: 'listen' } }
-      const device: ICallingTapDevice = { type: 'rtp', params: { addr: '127.0.0.1', port: 1234 } }
+      const tap: ICallingTapTapArg = { type: 'audio', direction: 'listen' }
+      const device: ICallingTapDeviceArg = { type: 'rtp', addr: '127.0.0.1', port: 1234 }
       const getMsg = () => new Execute({
         protocol: 'signalwire_service_random_uuid',
         method: 'call.tap',
-        params: { node_id: call.nodeId, call_id: call.id, control_id: 'mocked-uuid', tap, device }
+        params: {
+          node_id: call.nodeId, call_id: call.id, control_id: 'mocked-uuid', tap: { type: 'audio', params: { direction: 'listen' } }, device: { type: 'rtp', params: { addr: '127.0.0.1', port: 1234 } }
+        }
       })
 
       it('.tap() should wait until the tapping ends', done => {
@@ -1098,12 +1100,14 @@ describe('Call', () => {
     })
 
     describe('tap methods', () => {
-      const tap: ICallingTapTap = { type: 'audio', params: { direction: 'listen' } }
-      const device: ICallingTapDevice = { type: 'rtp', params: { addr: '127.0.0.1', port: 1234 } }
+      const tap: ICallingTapTapArg = { type: 'audio', direction: 'listen' }
+      const device: ICallingTapDeviceArg = { type: 'rtp', addr: '127.0.0.1', port: 1234 }
       const getMsg = () => new Execute({
         protocol: 'signalwire_service_random_uuid',
         method: 'call.tap',
-        params: { node_id: call.nodeId, call_id: call.id, control_id: 'mocked-uuid', tap, device }
+        params: {
+          node_id: call.nodeId, call_id: call.id, control_id: 'mocked-uuid', tap: { type: 'audio', params: { direction: 'listen' } }, device: { type: 'rtp', params: { addr: '127.0.0.1', port: 1234 } }
+        }
       })
 
 


### PR DESCRIPTION
Last commit changed the parameters to receive a flat object instead of the nested `params`.

Example:

```javascript
const tap = { type: 'audio' }
const device = { type: 'rtp', addr: '192.168.1.1', port: 1234 }
const tapAction = await call.tapAsync( tap, device )
```