### PR TITLE
Messaging send parameters tweaks

### DIFF
--- a/packages/common/src/relay/messaging/Messaging.ts
+++ b/packages/common/src/relay/messaging/Messaging.ts
@@ -25,6 +25,11 @@ export default class Messaging extends Relay {
   }
 
   async send(params: any): Promise<SendResult> {
+    const { from = '', to = '' } = params
+    params.from_number = from
+    params.to_number = to
+    delete params.from
+    delete params.to
     const msg = new Execute({
       protocol: this.session.relayProtocol,
       method: 'messaging.send',

--- a/packages/node/tests/relay/Messaging.test.ts
+++ b/packages/node/tests/relay/Messaging.test.ts
@@ -14,7 +14,7 @@ describe('Messaging', () => {
 
   describe('.send()', () => {
 
-    const messageOpts = { context: 'office', from_number: '8992222222', to_number: '8991111111', body: 'Hello' }
+    const messageOpts = { context: 'office', from: '8992222222', to: '8991111111', body: 'Hello' }
 
     it('should return a SendResult with success 200 response code', async done => {
       Connection.mockResponse.mockReturnValueOnce(JSON.parse('{"id":"uuid","jsonrpc":"2.0","result":{"result":{"code":"200","message":"message","message_id":"message-uuid"}}}'))


### PR DESCRIPTION
For consistency with Calling, `messaging.send()` accepts `from` and `to` instead of raw `from_number` and `to_number`.