### PR TITLE
WebRTC devices helpers

### DIFF
--- a/packages/common/src/BrowserSession.ts
+++ b/packages/common/src/BrowserSession.ts
@@ -1,10 +1,9 @@
 import BaseSession from './BaseSession'
-import Connection from './services/Connection'
 import BaseCall from './webrtc/BaseCall'
 import Call from './webrtc/Call'
 import { ICacheDevices, IAudioSettings, IVideoSettings, BroadcastParams, SubscribeParams, CallOptions } from './util/interfaces'
-import { registerOnce } from './services/Handler'
-import { SwEvent, SESSION_ID } from './util/constants'
+import { registerOnce, trigger } from './services/Handler'
+import { SwEvent, SESSION_ID, DeviceType } from './util/constants'
 import { State } from './util/constants/call'
 import { getDevices, scanResolutions, removeUnsupportedConstraints, checkDeviceIdConstraints, destructSubscribeResponse, getUserMedia } from './webrtc/helpers'
 import { findElementByType } from './util/helpers'
@@ -86,6 +85,46 @@ export default abstract class BrowserSession extends BaseSession {
         this.executeRaw(`#SPB ${dots}`)
       }
       this.executeRaw('#SPE')
+    })
+  }
+
+  /**
+   * Return the device list supported by the browser
+   */
+  getDevices(): Promise<MediaDeviceInfo[]> {
+    return getDevices().catch(error => {
+      trigger(SwEvent.MediaError, error, this.uuid)
+      return []
+    })
+  }
+
+  /**
+   * Return the device list supported by the browser
+   */
+  getVideoDevices(): Promise<MediaDeviceInfo[]> {
+    return getDevices(DeviceType.Video).catch(error => {
+      trigger(SwEvent.MediaError, error, this.uuid)
+      return []
+    })
+  }
+
+  /**
+   * Return the device list supported by the browser
+   */
+  getAudioInDevices(): Promise<MediaDeviceInfo[]> {
+    return getDevices(DeviceType.AudioIn).catch(error => {
+      trigger(SwEvent.MediaError, error, this.uuid)
+      return []
+    })
+  }
+
+  /**
+   * Return the device list supported by the browser
+   */
+  getAudioOutDevices(): Promise<MediaDeviceInfo[]> {
+    return getDevices(DeviceType.AudioOut).catch(error => {
+      trigger(SwEvent.MediaError, error, this.uuid)
+      return []
     })
   }
 

--- a/packages/common/src/BrowserSession.ts
+++ b/packages/common/src/BrowserSession.ts
@@ -162,7 +162,7 @@ export default abstract class BrowserSession extends BaseSession {
    * @deprecated
    */
   get devices() {
-    return this._devices
+    return this._devices || {}
   }
 
   /**
@@ -181,7 +181,7 @@ export default abstract class BrowserSession extends BaseSession {
    */
   get videoDevices() {
     logger.warn('This property has been deprecated. Use getVideoDevices() instead.')
-    return this._devices.videoinput
+    return this._devices.videoinput || {}
   }
 
   /**
@@ -189,7 +189,7 @@ export default abstract class BrowserSession extends BaseSession {
    */
   get audioInDevices() {
     logger.warn('This property has been deprecated. Use getAudioInDevices() instead.')
-    return this._devices.audioinput
+    return this._devices.audioinput || {}
   }
 
   /**
@@ -197,7 +197,7 @@ export default abstract class BrowserSession extends BaseSession {
    */
   get audioOutDevices() {
     logger.warn('This property has been deprecated. Use getAudioOutDevices() instead.')
-    return this._devices.audiooutput
+    return this._devices.audiooutput || {}
   }
 
   get mediaConstraints() {

--- a/packages/common/src/BrowserSession.ts
+++ b/packages/common/src/BrowserSession.ts
@@ -1,3 +1,4 @@
+import logger from './util/logger'
 import BaseSession from './BaseSession'
 import BaseCall from './webrtc/BaseCall'
 import Call from './webrtc/Call'
@@ -133,6 +134,7 @@ export default abstract class BrowserSession extends BaseSession {
    * @deprecated
    */
   async refreshDevices() {
+    logger.warn('This method has been deprecated. Use getDevices() instead.')
     const cache = {};
     ['videoinput', 'audioinput', 'audiooutput'].map((kind: string) => {
       cache[kind] = {}
@@ -175,6 +177,7 @@ export default abstract class BrowserSession extends BaseSession {
    * @deprecated
    */
   get videoDevices() {
+    logger.warn('This property has been deprecated. Use getVideoDevices() instead.')
     return this._devices.videoinput
   }
 
@@ -182,6 +185,7 @@ export default abstract class BrowserSession extends BaseSession {
    * @deprecated
    */
   get audioInDevices() {
+    logger.warn('This property has been deprecated. Use getAudioInDevices() instead.')
     return this._devices.audioinput
   }
 
@@ -189,6 +193,7 @@ export default abstract class BrowserSession extends BaseSession {
    * @deprecated
    */
   get audioOutDevices() {
+    logger.warn('This property has been deprecated. Use getAudioOutDevices() instead.')
     return this._devices.audiooutput
   }
 

--- a/packages/common/src/BrowserSession.ts
+++ b/packages/common/src/BrowserSession.ts
@@ -286,7 +286,7 @@ export default abstract class BrowserSession extends BaseSession {
   async vertoSubscribe({ nodeId, channels: eventChannel = [], handler }: SubscribeParams) {
     eventChannel = eventChannel.filter(channel => channel && !this._existsSubscription(this.relayProtocol, channel))
     if (!eventChannel.length) {
-      return
+      return {}
     }
     const msg = new Subscribe({ sessid: this.sessionid, eventChannel })
     if (nodeId) {
@@ -304,7 +304,7 @@ export default abstract class BrowserSession extends BaseSession {
   async vertoUnsubscribe({ nodeId, channels: eventChannel = [] }: SubscribeParams) {
     eventChannel = eventChannel.filter(channel => channel && this._existsSubscription(this.relayProtocol, channel))
     if (!eventChannel.length) {
-      return
+      return {}
     }
     const msg = new Unsubscribe({ sessid: this.sessionid, eventChannel })
     if (nodeId) {

--- a/packages/common/src/BrowserSession.ts
+++ b/packages/common/src/BrowserSession.ts
@@ -130,12 +130,32 @@ export default abstract class BrowserSession extends BaseSession {
 
   /**
    * Refresh the device list doing an enumerateDevices
+   * @deprecated
    */
   async refreshDevices() {
-    this._devices = await getDevices()
+    const cache = {};
+    ['videoinput', 'audioinput', 'audiooutput'].map((kind: string) => {
+      cache[kind] = {}
+      Object.defineProperty(cache[kind], 'toArray', {
+        value: function () {
+          return Object.keys(this).map(k => this[k])
+        }
+      })
+    })
+    const devices = await this.getDevices()
+    devices.forEach((t: MediaDeviceInfo) => {
+      if (cache.hasOwnProperty(t.kind)) {
+        cache[t.kind][t.deviceId] = t
+      }
+    })
+
+    this._devices = cache
     return this.devices
   }
 
+  /**
+   * @deprecated
+   */
   get devices() {
     return this._devices
   }
@@ -151,14 +171,23 @@ export default abstract class BrowserSession extends BaseSession {
     }
   }
 
+  /**
+   * @deprecated
+   */
   get videoDevices() {
     return this._devices.videoinput
   }
 
+  /**
+   * @deprecated
+   */
   get audioInDevices() {
     return this._devices.audioinput
   }
 
+  /**
+   * @deprecated
+   */
   get audioOutDevices() {
     return this._devices.audiooutput
   }

--- a/packages/common/src/BrowserSession.ts
+++ b/packages/common/src/BrowserSession.ts
@@ -14,6 +14,10 @@ import { stopStream } from './util/webrtc'
 
 export default abstract class BrowserSession extends BaseSession {
   public calls: { [callId: string]: BaseCall } = {}
+  public micId: string
+  public micLabel: string
+  public camId: string
+  public camLabel: string
 
   private _iceServers: RTCIceServer[] = []
   private _localElement: HTMLMediaElement = null
@@ -26,7 +30,6 @@ export default abstract class BrowserSession extends BaseSession {
   protected _speaker: string = null
 
   async connect(): Promise<void> {
-    await this.refreshDevices()
     this.sessionid = await localStorage.getItem(SESSION_ID)
     super.connect()
   }
@@ -205,6 +208,8 @@ export default abstract class BrowserSession extends BaseSession {
     const { micId, micLabel, ...constraints } = settings
     removeUnsupportedConstraints(constraints)
     this._audioConstraints = await checkDeviceIdConstraints(micId, micLabel, 'audioinput', constraints)
+    this.micId = micId
+    this.micLabel = micLabel
     return this._audioConstraints
   }
 
@@ -220,6 +225,8 @@ export default abstract class BrowserSession extends BaseSession {
     const { camId, camLabel, ...constraints } = settings
     removeUnsupportedConstraints(constraints)
     this._videoConstraints = await checkDeviceIdConstraints(camId, camLabel, 'videoinput', constraints)
+    this.camId = camId
+    this.camLabel = camLabel
     return this._videoConstraints
   }
 

--- a/packages/common/src/BrowserSession.ts
+++ b/packages/common/src/BrowserSession.ts
@@ -251,12 +251,7 @@ export default abstract class BrowserSession extends BaseSession {
   }
 
   set speaker(deviceId: string) {
-    const knownSpeakers = Object.keys(this.audioOutDevices)
-    if (knownSpeakers.includes(deviceId)) {
-      this._speaker = deviceId
-    } else {
-      throw new Error(`Unknown device ${deviceId}.`)
-    }
+    this._speaker = deviceId
   }
 
   get speaker() {

--- a/packages/common/src/util/constants/index.ts
+++ b/packages/common/src/util/constants/index.ts
@@ -74,3 +74,9 @@ export enum BladeMethod {
   Broadcast = 'blade.broadcast',
   Disconnect = 'blade.disconnect'
 }
+
+export enum DeviceType {
+  Video = 'videoinput',
+  AudioIn = 'audioinput',
+  AudioOut = 'audiooutput'
+}

--- a/packages/common/src/util/interfaces.ts
+++ b/packages/common/src/util/interfaces.ts
@@ -86,7 +86,9 @@ export interface CallOptions {
   attach?: boolean
   useStereo?: boolean
   micId?: string
+  micLabel?: string
   camId?: string
+  camLabel?: string
   speakerId?: string
   userVariables?: Object
   screenShare?: boolean

--- a/packages/common/src/webrtc/BaseCall.ts
+++ b/packages/common/src/webrtc/BaseCall.ts
@@ -35,8 +35,8 @@ export default abstract class BaseCall {
   private _iceDone: boolean = false
 
   constructor(protected session: BrowserSession, opts?: CallOptions) {
-    const { iceServers, speaker: speakerId, localElement, remoteElement, mediaConstraints: { audio, video } } = session
-    this.options = Object.assign({}, DEFAULT_CALL_OPTIONS, { audio, video, iceServers, localElement, remoteElement, speakerId }, opts)
+    const { iceServers, speaker: speakerId, micId, micLabel, camId, camLabel, localElement, remoteElement, mediaConstraints: { audio, video } } = session
+    this.options = Object.assign({}, DEFAULT_CALL_OPTIONS, { audio, video, iceServers, localElement, remoteElement, micId, micLabel, camId, camLabel, speakerId }, opts)
 
     this._onMediaError = this._onMediaError.bind(this)
     this._init()

--- a/packages/common/src/webrtc/Peer.ts
+++ b/packages/common/src/webrtc/Peer.ts
@@ -121,7 +121,8 @@ export default class Peer {
     if (streamIsValid(this.options.localStream)) {
       return this.options.localStream
     }
-    return getUserMedia(getMediaConstraints(this.options))
+    const constraints = await getMediaConstraints(this.options)
+    return getUserMedia(constraints)
   }
 
   private _isOffer(): boolean {

--- a/packages/common/src/webrtc/helpers.ts
+++ b/packages/common/src/webrtc/helpers.ts
@@ -124,7 +124,7 @@ const assureDeviceId = async (id: string, label: string, kind: MediaDeviceInfo['
 const removeUnsupportedConstraints = (constraints: MediaTrackConstraints): void => {
   const supported = WebRTC.getSupportedConstraints()
   Object.keys(constraints).map(key => {
-    if (!supported.hasOwnProperty(key)) {
+    if (!supported.hasOwnProperty(key) || constraints[key] === null || constraints[key] === undefined) {
       delete constraints[key]
     }
   })

--- a/packages/common/src/webrtc/helpers.ts
+++ b/packages/common/src/webrtc/helpers.ts
@@ -81,21 +81,27 @@ const scanResolutions = async (deviceId: string) => {
   return supported
 }
 
-const getMediaConstraints = (options: CallOptions): MediaStreamConstraints => {
-  let { audio = true } = options
-  if (options.micId) {
-    if (typeof audio === 'boolean') {
-      audio = {}
+const getMediaConstraints = async (options: CallOptions): Promise<MediaStreamConstraints> => {
+  let { audio = true, micId, micLabel = '' } = options
+  if (micId) {
+    micId = await assureDeviceId(micId, micLabel, DeviceType.AudioIn).catch(error => null)
+    if (micId) {
+      if (typeof audio === 'boolean') {
+        audio = {}
+      }
+      audio.deviceId = { exact: micId }
     }
-    audio.deviceId = { exact: options.micId }
   }
 
-  let { video = false } = options
-  if (options.camId) {
-    if (typeof video === 'boolean') {
-      video = {}
+  let { video = false, camId, camLabel = '' } = options
+  if (camId) {
+    camId = await assureDeviceId(camId, camLabel, DeviceType.Video).catch(error => null)
+    if (camId) {
+      if (typeof video === 'boolean') {
+        video = {}
+      }
+      video.deviceId = { exact: camId }
     }
-    video.deviceId = { exact: options.camId }
   }
 
   return { audio, video }

--- a/packages/common/src/webrtc/helpers.ts
+++ b/packages/common/src/webrtc/helpers.ts
@@ -46,7 +46,7 @@ const getDevices = async (kind: string = null): Promise<MediaDeviceInfo[]> => {
   const found = []
   devices = devices.filter(({ kind, groupId }: MediaDeviceInfo) => {
     if (!groupId) {
-      return true;
+      return true
     }
     const key = `${kind}-${groupId}`
     if (!found.includes(key)) {
@@ -85,7 +85,8 @@ const scanResolutions = async (deviceId: string) => {
 }
 
 const getMediaConstraints = async (options: CallOptions): Promise<MediaStreamConstraints> => {
-  let { audio = true, micId, micLabel = '' } = options
+  let { audio = true, micId } = options
+  const { micLabel = '' } = options
   if (micId) {
     micId = await assureDeviceId(micId, micLabel, DeviceType.AudioIn).catch(error => null)
     if (micId) {
@@ -96,7 +97,8 @@ const getMediaConstraints = async (options: CallOptions): Promise<MediaStreamCon
     }
   }
 
-  let { video = false, camId, camLabel = '' } = options
+  let { video = false, camId } = options
+  const { camLabel = '' } = options
   if (camId) {
     camId = await assureDeviceId(camId, camLabel, DeviceType.Video).catch(error => null)
     if (camId) {

--- a/packages/common/src/webrtc/helpers.ts
+++ b/packages/common/src/webrtc/helpers.ts
@@ -45,6 +45,9 @@ const getDevices = async (kind: string = null): Promise<MediaDeviceInfo[]> => {
   }
   const found = []
   devices = devices.filter(({ kind, groupId }: MediaDeviceInfo) => {
+    if (!groupId) {
+      return true;
+    }
     const key = `${kind}-${groupId}`
     if (!found.includes(key)) {
       found.push(key)

--- a/packages/common/tests/setup/connection.ts
+++ b/packages/common/tests/setup/connection.ts
@@ -1,3 +1,4 @@
+import logger from '../../src/util/logger'
 const Connection = require('../../src/services/Connection')
 jest.mock('../../src/services/Connection')
 
@@ -7,3 +8,6 @@ jest.mock('uuid', () => {
     v4: jest.fn(() => 'mocked-uuid')
   };
 });
+
+
+logger.disableAll()

--- a/packages/common/tests/setup/webrtcMocks.ts
+++ b/packages/common/tests/setup/webrtcMocks.ts
@@ -94,7 +94,8 @@ class MediaStreamTrackMock implements MediaStreamTrack {
   }
 
   stop() {
-    throw new Error("Method not implemented.");
+    this.enabled = false
+    this.readyState = 'ended'
   }
 
   addEventListener(type: any, listener: any, options?: any) {

--- a/packages/common/tests/webrtc/helpers.test.ts
+++ b/packages/common/tests/webrtc/helpers.test.ts
@@ -1,5 +1,5 @@
 import { findElementByType } from '../../../common/src/util/helpers'
-import { sdpStereoHack, sdpMediaOrderHack } from '../../src/webrtc/helpers'
+import { sdpStereoHack, sdpMediaOrderHack, getDevices } from '../../src/webrtc/helpers'
 
 describe('Helpers browser functions', () => {
   describe('findElementByType', () => {
@@ -55,6 +55,58 @@ describe('Helpers browser functions', () => {
 
     it('if audio already comes first, do nothing', () => {
       expect(sdpMediaOrderHack(ANSWER, OFFER_OK)).toEqual(ANSWER)
+    })
+  })
+
+  describe('getDevices', () => {
+    it('should return the device list removing the duplicated', async done => {
+      const devices = await getDevices()
+      expect(devices).toHaveLength(5)
+      done()
+    })
+
+    it('should return the audioIn device list with kind audioinput', async done => {
+      const devices = await getDevices('audioinput')
+      expect(devices).toHaveLength(2)
+      expect(devices[0].deviceId).toEqual('default')
+      done()
+    })
+
+    it('should return the video device list with kind videoinput', async done => {
+      const devices = await getDevices('videoinput')
+      expect(devices).toHaveLength(2)
+      expect(devices[0].deviceId).toEqual('2060bf50ab9c29c12598bf4eafeafa71d4837c667c7c172bb4407ec6c5150206')
+      done()
+    })
+
+    it('should return the audioOut device list with kind audiooutput', async done => {
+      const devices = await getDevices('audiooutput')
+      expect(devices).toHaveLength(1)
+      expect(devices[0].deviceId).toEqual('default')
+      done()
+    })
+
+    describe('on safari without deviceId or label', () => {
+      const ENUMERATED_MEDIA_DEVICES_SAFARI = [
+        { 'deviceId': 'default', 'kind': 'audioinput', 'label': '', 'groupId': '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f' },
+        { 'deviceId': '', 'kind': 'audioinput', 'label': '', 'groupId': '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f' },
+        { 'deviceId': '', 'kind': 'audioinput', 'label': '', 'groupId': '67a612f4ac80c6c9854b50d664348e69b5a11421a0ba8d68e2c00f3539992b4c' },
+
+        { 'deviceId': 'default', 'kind': 'videoinput', 'label': '', 'groupId': '72e8ab9444144c3f8e04276a5801e520e83fc801702a6ef68e9e344083f6f6ce' },
+        { 'deviceId': '', 'kind': 'videoinput', 'label': '', 'groupId': '67a612f4ac80c6c9854b50d664348e69b5a11421a0ba8d68e2c00f3539992b4c' },
+
+        { 'deviceId': 'default', 'kind': 'audiooutput', 'label': '', 'groupId': '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f' },
+        { 'deviceId': '', 'kind': 'audiooutput', 'label': '', 'groupId': '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f' },
+      ]
+      it('should return the device list removing the duplicated', async done => {
+        // @ts-ignore
+        navigator.mediaDevices.enumerateDevices.mockResolvedValueOnce(ENUMERATED_MEDIA_DEVICES_SAFARI)
+        const devices = await getDevices()
+        expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1)
+        expect(devices).toHaveLength(5)
+        expect(devices[0].label).toEqual('Default - External Microphone (Built-in)')
+        done()
+      })
     })
   })
 })

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -27,6 +27,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Security
 - Update dependencies
 
+## [1.2.0-beta.1] - 2019-08-02
+### Added
+- New methods to manage browser devices: `getDevices()`, `getVideoDevices()`, `getAudioInDevices()`, `getAudioOutDevices()`.
+### Deprecated
+- Deprecated getters to retrieve cached values for devices: `devices`, `videoDevices`, `audioInDevices`, `audioOutDevices`.
+- Deprecated `refreshDevices()` method to refresh cached devices. Use `getDevices()` instead.
+
 ## [1.1.3] - 2019-07-31
 ### Changed
 - Auto-discover webrtc devices if all `deviceIds` or `labels` are empty. (Help on Safari)

--- a/packages/js/package-lock.json
+++ b/packages/js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalwire/js",
-  "version": "1.1.3",
+  "version": "1.2.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalwire/js",
-  "version": "1.1.3",
+  "version": "1.2.0-beta.1",
   "description": "Relay SDK for JavaScript to connect to SignalWire.",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "main": "dist/index.min.js",

--- a/packages/js/tests/Verto.test.ts
+++ b/packages/js/tests/Verto.test.ts
@@ -91,7 +91,7 @@ describe('Verto', () => {
     it('should do nothing if subscription already exists and return NULL', async () => {
       instance.subscriptions = { [VERTO_PROTOCOL]: { 'channel-already-there': {} } }
       const response = await instance.subscribe({ channels: ['channel-already-there'], handler: noop })
-      expect(response).toBeUndefined()
+      expect(response).toEqual({})
       expect(Connection.mockSend.mock.calls).toHaveLength(0)
       expect(instance.subscriptions[VERTO_PROTOCOL]).toHaveProperty('channel-already-there')
     })
@@ -119,7 +119,7 @@ describe('Verto', () => {
     it('should do nothing if subscription does not exists', async () => {
       const cName = 'channel-fake'
       const response = await instance.unsubscribe({ channels: [cName] })
-      expect(response).toBeUndefined()
+      expect(response).toEqual({})
       expect(instance.subscriptions).not.toHaveProperty(VERTO_PROTOCOL)
     })
   })


### PR DESCRIPTION
This PR add a retry-logic required on Safari (macOS and iOS).

Every time the user needs to _use_ a device (or retrieve them as a list), the SDK checks if `deviceId` and `label` are valid for each MediaDevice. If not, we must fire a `getUserMedia` request and then refresh the device list.

These properties/methods: `refreshDevices`, `videoDevices`, `audioInDevices`, `audioOutDevices` have been deprecated since they are evaluated on a cached object that is not valid **only** on iPads. (`ids` of each device will change on each hashchange event).
