### PR TITLE
Fix "unhandled promise rejection" on receive

### DIFF
--- a/packages/common/src/services/Receive.ts
+++ b/packages/common/src/services/Receive.ts
@@ -21,7 +21,11 @@ export default async (session: BaseSession, contexts: string | string[]): Promis
   const be = new Execute({ protocol, method, params: { contexts } })
   const response = await session.execute(be).catch(error => {
     logger.error(`Error registering contexts: [${error.code}] ${error.message}`)
+    return null
   })
+  if (response === null) {
+    return false
+  }
   logger.info(response.message)
   session.contexts = session.contexts.concat(contexts)
 

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Avoid `Unhandled promise rejection` error in case of Relay errors while registering contexts.
+
 ## [2.1.0] - 2019-07-30
 ### Added
 - Create your own Relay Tasks and enable `onTask` method on RelayConsumer to receive/handle them.


### PR DESCRIPTION
Avoid the `Unhandled promise rejection` error in case of failure response on a `receive` request.