### PR TITLE
Release JS SDK v1.2.0

### DIFF
--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.0] - 2019-08-22
 ### Fixed
 - Try to re-establish the previous protocol only if the signature has not changed.
 ### Security

--- a/packages/js/package-lock.json
+++ b/packages/js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalwire/js",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalwire/js",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0",
   "description": "Relay SDK for JavaScript to connect to SignalWire.",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "main": "dist/index.min.js",

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New methods to manage devices: `getDevices()`, `getVideoDevices()`, `getAudioInDevices()`, `getAudioOutDevices()`.
+### Deprecated
+- Deprecated getters to retrieve cached values for devices: `devices`, `videoDevices`, `audioInDevices`, `audioOutDevices`.
+- Deprecated `refreshDevices()` method to refresh cached devices. Use `getDevices()` instead.
 ### Fixed
 - Try to re-establish the previous protocol only if the signature has not changed.
 


### PR DESCRIPTION
This version is in beta since Aug 3, with the addition of  https://github.com/signalwire/signalwire-node/pull/162 we can push `v1.2.0` out.