### PR TITLE
Bugfix on webrtc audio stereo

### DIFF
--- a/packages/common/src/util/constants/call.ts
+++ b/packages/common/src/util/constants/call.ts
@@ -8,7 +8,7 @@ export const DEFAULT_CALL_OPTIONS: CallOptions = {
   callerNumber: '',
   audio: true,
   video: false,
-  useStereo: true,
+  useStereo: false,
   attach: false,
   screenShare: false,
   userVariables: {}

--- a/packages/common/src/webrtc/Peer.ts
+++ b/packages/common/src/webrtc/Peer.ts
@@ -93,7 +93,7 @@ export default class Peer {
     if (!this._isAnswer()) {
       return
     }
-    const { remoteSdp, useStereo = true } = this.options
+    const { remoteSdp, useStereo } = this.options
     const sdp = useStereo ? sdpStereoHack(remoteSdp) : remoteSdp
     const sessionDescr: RTCSessionDescription = sdpToJsonHack({ sdp, type: PeerType.Offer })
     this.instance.setRemoteDescription(sessionDescr)

--- a/packages/common/src/webrtc/helpers.ts
+++ b/packages/common/src/webrtc/helpers.ts
@@ -161,7 +161,7 @@ const sdpStereoHack = (sdp: string) => {
   const sdpLines = sdp.split(endOfLine)
 
   const opusIndex = sdpLines.findIndex(s => /^a=rtpmap/.test(s) && /opus\/48000/.test(s))
-  if (!opusIndex) {
+  if (opusIndex < 0) {
     return sdp
   }
 

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2019-08-26
+### Fixed
+- Bugfix on SDP hack to force stereo audio if browser does not support it.
+### Changed
+- Default `useStereo` to false since is not supported by all browsers.
+
 ## [1.2.0] - 2019-08-22
 ### Fixed
 - Try to re-establish the previous protocol only if the signature has not changed.

--- a/packages/js/examples/vanilla-calling/index.html
+++ b/packages/js/examples/vanilla-calling/index.html
@@ -9,7 +9,7 @@
   <script type="text/javascript" src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
 
   <!-- Include the SignalWire Relay JS SDK -->
-  <script type="text/javascript" src="https://cdn.signalwire.com/libs/js/relay/1.1.0/relay.min.js"></script>
+  <script type="text/javascript" src="https://cdn.signalwire.com/libs/js/relay/1.2.1/relay.min.js"></script>
 
   <!-- To style up the demo a little -->
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" />

--- a/packages/js/package-lock.json
+++ b/packages/js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalwire/js",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalwire/js",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Relay SDK for JavaScript to connect to SignalWire.",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "main": "dist/index.min.js",


### PR DESCRIPTION
This is related to #167. `stereo=1` is not supported in all browsers so i changed the flag to be default to `false` and fix a JS bug on the SDP hack to enable it.

Closes #167 