### PR TITLE
waitForBeep snake_case to be consistent with other params

### DIFF
--- a/packages/common/src/relay/calling/Call.ts
+++ b/packages/common/src/relay/calling/Call.ts
@@ -339,16 +339,16 @@ export default class Call implements ICall {
     return new DetectAction(component)
   }
 
-  async detectAnsweringMachine({ timeout, waitForBeep = false, ...params }: ICallingDetectArg = {}): Promise<DetectResult> {
-    const component = new Detect(this, { type: CallDetectType.Machine, params }, timeout, waitForBeep)
+  async detectAnsweringMachine({ timeout, wait_for_beep = false, ...params }: ICallingDetectArg = {}): Promise<DetectResult> {
+    const component = new Detect(this, { type: CallDetectType.Machine, params }, timeout, wait_for_beep)
     this._addComponent(component)
     await component._waitFor(CallDetectState.Machine, CallDetectState.Human, CallDetectState.Unknown)
 
     return new DetectResult(component)
   }
 
-  async detectAnsweringMachineAsync({ timeout, waitForBeep = false, ...params }: ICallingDetectArg = {}): Promise<DetectAction> {
-    const component = new Detect(this, { type: CallDetectType.Machine, params }, timeout, waitForBeep)
+  async detectAnsweringMachineAsync({ timeout, wait_for_beep = false, ...params }: ICallingDetectArg = {}): Promise<DetectAction> {
+    const component = new Detect(this, { type: CallDetectType.Machine, params }, timeout, wait_for_beep)
     this._addComponent(component)
     await component.execute()
 

--- a/packages/common/src/util/interfaces.ts
+++ b/packages/common/src/util/interfaces.ts
@@ -249,7 +249,7 @@ export interface ICallingDetect {
 export interface ICallingDetectArg extends ICallingDetectParams {
   type?: string
   timeout?: number
-  waitForBeep?: boolean
+  wait_for_beep?: boolean
 }
 
 export interface ICallingTapTapParams {

--- a/packages/node/examples/calling/answering_machine_detection.js
+++ b/packages/node/examples/calling/answering_machine_detection.js
@@ -15,7 +15,7 @@ const consumer = new RelayConsumer({
     }
 
     // Try to detect a machine and wait for 'beep'
-    const { successful, result, event } = await call.amd({ waitForBeep: true })
+    const { successful, result, event } = await call.amd({ wait_for_beep: true })
 
     if (successful) {
       console.log('Detection result:', result, 'Last event:', event)

--- a/packages/node/tests/relay/Call.test.ts
+++ b/packages/node/tests/relay/Call.test.ts
@@ -667,7 +667,7 @@ describe('Call', () => {
         done()
       })
 
-      it('.detectAnsweringMachine() without waitForBeep should resolve on the first valid event', done => {
+      it('.detectAnsweringMachine() without wait_for_beep should resolve on the first valid event', done => {
         call.detectAnsweringMachine({ initial_timeout: 5, timeout: 30 }).then(result => {
           expect(result).toBeInstanceOf(DetectResult)
           expect(result.successful).toBe(true)
@@ -679,8 +679,8 @@ describe('Call', () => {
         session.calling.notificationHandler(_notificationMachineUnknown)
       })
 
-      it('.detectAnsweringMachine() with waitForBeep should wait until READY in case of MACHINE', done => {
-        call.detectAnsweringMachine({ initial_timeout: 5, timeout: 30, waitForBeep: true }).then(result => {
+      it('.detectAnsweringMachine() with wait_for_beep should wait until READY in case of MACHINE', done => {
+        call.detectAnsweringMachine({ initial_timeout: 5, timeout: 30, wait_for_beep: true }).then(result => {
           expect(result).toBeInstanceOf(DetectResult)
           expect(result.successful).toBe(true)
           expect(result.type).toBe('machine')
@@ -694,8 +694,8 @@ describe('Call', () => {
         session.calling.notificationHandler(_notificationMachineNotReady) // This will be ignored by Detect component
       })
 
-      it('.detectAnsweringMachine() with waitForBeep should resolve if the first event is not MACHINE', done => {
-        call.detectAnsweringMachine({ initial_timeout: 5, timeout: 30, waitForBeep: true }).then(result => {
+      it('.detectAnsweringMachine() with wait_for_beep should resolve if the first event is not MACHINE', done => {
+        call.detectAnsweringMachine({ initial_timeout: 5, timeout: 30, wait_for_beep: true }).then(result => {
           expect(result).toBeInstanceOf(DetectResult)
           expect(result.successful).toBe(true)
           expect(result.type).toBe('machine')


### PR DESCRIPTION
Writing docs i noticed that all other Relay params are `snake_case` so i changed `waitForBeep` to be `wait_for_beep`.