### PR TITLE
Terminate components if the call is ended

### DIFF
--- a/packages/common/src/relay/calling/components/BaseComponent.ts
+++ b/packages/common/src/relay/calling/components/BaseComponent.ts
@@ -44,6 +44,9 @@ export abstract class BaseComponent {
 
   /** Execute message and return the Relay response */
   async execute(): Promise<any> {
+    if (this.call.ended) {
+      return this.terminate()
+    }
     if (!this.method) {
       return null
     }

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 - Minor change at the lower level APIs: using `calling.` instead of `call.` prefix for calling methods.
 - Flattened parameters for _record_, _play_, _prompt_, _detect_ and _tap_ calling methods.
+- Do not send a Relay request if the Call is ended, preventing the error "Call does not exists".
 
 ### Added
 - New methods to perform answering machine detection: `amd` (alias to `detectAnsweringMachine`) and `amdAsync` (alias to `detectAnsweringMachineAsync`).

--- a/packages/node/tests/relay/Call.test.ts
+++ b/packages/node/tests/relay/Call.test.ts
@@ -105,6 +105,7 @@ describe('Call', () => {
   describe('with success response code 200', () => {
 
     const _stateNotificationAnswered = JSON.parse(`{"event_type":"calling.call.state","params":{"call_state":"answered","direction":"inbound","device":{"type":"phone","params":{"from_number":"+1234","to_number":"15678"}},"call_id":"call-id","node_id":"node-id"}}`)
+    const _stateNotificationEnding = JSON.parse(`{"event_type":"calling.call.state","params":{"call_state":"ending","end_reason":"busy","direction":"inbound","device":{"type":"phone","params":{"from_number":"+1234","to_number":"15678"}},"call_id":"call-id","node_id":"node-id"}}`)
     const _stateNotificationEnded = JSON.parse(`{"event_type":"calling.call.state","params":{"call_state":"ended","end_reason":"busy","direction":"inbound","device":{"type":"phone","params":{"from_number":"+1234","to_number":"15678"}},"call_id":"call-id","node_id":"node-id"}}`)
     const _recordNotification = JSON.parse(`{"event_type":"calling.call.record","params":{"state":"finished","record":{"audio":{"format":"mp3","direction":"speak","stereo":false}},"url":"record.mp3","control_id":"mocked-uuid","size":4096,"duration":4,"call_id":"call-id","node_id":"node-id"}}`)
     const _connectNotification = JSON.parse(`{"event_type":"calling.call.connect","params":{"connect_state":"connected","peer":{"call_id":"peer-call-id","node_id":"peer-node-id","device":{"type":"phone","params":{"from_number":"+1234","to_number":"+15678"}}},"call_id":"call-id","node_id":"node-id"}}`)
@@ -170,6 +171,17 @@ describe('Call', () => {
         done()
       })
       session.calling.notificationHandler(_stateNotificationEnded)
+    })
+
+    it('.hangup() on an ended call should fail', done => {
+      session.calling.notificationHandler(_stateNotificationEnding)
+      call.hangup().then(result => {
+        expect(result).toBeInstanceOf(HangupResult)
+        expect(result.successful).toBe(false)
+        expect(Connection.mockSend).not.toHaveBeenCalled()
+        Connection.mockResponse() // Force-consume mock request
+        done()
+      })
     })
 
     describe('recording methods', () => {


### PR DESCRIPTION
This PR add a small check to prevent a request in case the call is `ended` (with _ending_ or _ended_ state).

In that case the component is rejected and flagged as `failed`.