### PR TITLE
Remove deprecated warnings

### DIFF
--- a/packages/common/src/webrtc/BaseCall.ts
+++ b/packages/common/src/webrtc/BaseCall.ts
@@ -672,19 +672,17 @@ export default abstract class BaseCall {
       }
     }
 
-    instance.ontrack = event => {
+    instance.addEventListener('track', (event: RTCTrackEvent) => {
       this.options.remoteStream = event.streams[0]
-
-      if (this.options.screenShare === true) {
-        return
+      const { remoteElement, remoteStream, screenShare } = this.options
+      if (screenShare === false) {
+        attachMediaStream(remoteElement, remoteStream)
       }
-      const { remoteElement, remoteStream } = this.options
-      attachMediaStream(remoteElement, remoteStream)
-    }
-    // @ts-ignore
-    instance.onaddstream = (event: MediaStreamEvent) => {
+    })
+
+    instance.addEventListener('addstream', (event: MediaStreamEvent) => {
       this.options.remoteStream = event.stream
-    }
+    })
   }
 
   private _checkConferenceSerno = (serno: number) => {

--- a/packages/common/src/webrtc/Peer.ts
+++ b/packages/common/src/webrtc/Peer.ts
@@ -63,7 +63,7 @@ export default class Peer {
       })
     const { localElement, localStream = null, screenShare = false } = this.options
     if (streamIsValid(localStream)) {
-      if (this.instance.hasOwnProperty('addTrack')) {
+      if (typeof this.instance.addTrack === 'function') {
         localStream.getTracks().forEach(t => this.instance.addTrack(t, localStream))
       } else {
         // @ts-ignore

--- a/packages/common/tests/setup/browsers.ts
+++ b/packages/common/tests/setup/browsers.ts
@@ -11,6 +11,7 @@ if (typeof window !== 'undefined') {
           createAnswer: () => { },
           setLocalDescription: () => { },
           setRemoteDescription: () => { },
+          addEventListener: (event: string, cb: Function) => { },
         }
       }
     }

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+<!-- ## [Unreleased] -->
+## [1.2.3] - 2019-10-29
 ### Fixed
 - Update and use the proper extension to open the screenshare. Even after a transfer.
 - Remove deprecated warnings and minor bug fixes.

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 ### Fixed
 - Update and use the proper extension to open the screenshare. Even after a transfer.
+- Remove deprecated warnings and minor bug fixes.
 
 ## [1.2.2] - 2019-09-27
 ### Added

--- a/packages/js/package-lock.json
+++ b/packages/js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalwire/js",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalwire/js",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Relay SDK for JavaScript to connect to SignalWire.",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "main": "dist/index.min.js",


### PR DESCRIPTION
This includes the next release for the browser SDK `v1.2.3`