### PR TITLE
Calling refactoring

### DIFF
--- a/packages/common/src/relay/calling/components/Answer.ts
+++ b/packages/common/src/relay/calling/components/Answer.ts
@@ -1,14 +1,11 @@
 import { BaseComponent } from './BaseComponent'
-import { CallNotification, CallState } from '../../../util/constants/relay'
+import { CallNotification, CallState, CallMethod } from '../../../util/constants/relay'
 import Event from '../Event'
 
 export class Answer extends BaseComponent {
   public eventType: string = CallNotification.State
+  public method: string = CallMethod.Answer
   public controlId: string = this.call.tag
-
-  get method(): string {
-    return 'calling.answer'
-  }
 
   get payload(): any {
     return {

--- a/packages/common/src/relay/calling/components/Await.ts
+++ b/packages/common/src/relay/calling/components/Await.ts
@@ -4,11 +4,8 @@ import Event from '../Event'
 
 export class Await extends BaseComponent {
   public eventType: string = CallNotification.State
+  public method = null
   public controlId: string = this.call.tag
-
-  get method(): string {
-    return null
-  }
 
   get payload(): any {
     return null

--- a/packages/common/src/relay/calling/components/BaseComponent.ts
+++ b/packages/common/src/relay/calling/components/BaseComponent.ts
@@ -37,7 +37,7 @@ export abstract class BaseComponent {
   }
 
   /** Relay method to execute */
-  abstract get method(): string
+  abstract method: string = null
 
   /** Payload sent to Relay in requests */
   abstract get payload(): any

--- a/packages/common/src/relay/calling/components/Connect.ts
+++ b/packages/common/src/relay/calling/components/Connect.ts
@@ -1,11 +1,12 @@
 import { BaseComponent } from './BaseComponent'
 import { DeepArray, ICallDevice, IRelayCallingPlay } from '../../../util/interfaces'
-import { CallNotification, CallConnectState } from '../../../util/constants/relay'
+import { CallNotification, CallConnectState, CallMethod } from '../../../util/constants/relay'
 import Call from '../Call'
 import Event from '../Event'
 
 export class Connect extends BaseComponent {
   public eventType: string = CallNotification.Connect
+  public method: string = CallMethod.Connect
   public controlId: string = this.call.tag
 
   constructor(
@@ -14,10 +15,6 @@ export class Connect extends BaseComponent {
     public ringback?: IRelayCallingPlay
   ) {
     super(call)
-  }
-
-  get method(): string {
-    return 'calling.connect'
   }
 
   get payload(): any {

--- a/packages/common/src/relay/calling/components/Detect.ts
+++ b/packages/common/src/relay/calling/components/Detect.ts
@@ -1,6 +1,6 @@
 import { Controllable } from './Controllable'
 import { IRelayCallingDetect } from '../../../util/interfaces'
-import { CallNotification, CallDetectState, CallDetectType } from '../../../util/constants/relay'
+import { CallNotification, CallDetectState, CallDetectType, CallMethod } from '../../../util/constants/relay'
 import Call from '../Call'
 import Event from '../Event'
 
@@ -9,6 +9,7 @@ const _machineStateEvents: string[] = [CallDetectState.Ready, CallDetectState.No
 
 export class Detect extends Controllable {
   public eventType: string = CallNotification.Detect
+  public method: string = CallMethod.Detect
   public controlId: string = this.controlId
 
   public type: string
@@ -24,10 +25,6 @@ export class Detect extends Controllable {
     private _waitForBeep: boolean = false
   ) {
     super(call)
-  }
-
-  get method(): string {
-    return 'calling.detect'
   }
 
   get payload(): any {

--- a/packages/common/src/relay/calling/components/Dial.ts
+++ b/packages/common/src/relay/calling/components/Dial.ts
@@ -1,14 +1,11 @@
 import { BaseComponent } from './BaseComponent'
-import { CallNotification, CallState } from '../../../util/constants/relay'
+import { CallNotification, CallState, CallMethod } from '../../../util/constants/relay'
 import Event from '../Event'
 
 export class Dial extends BaseComponent {
   public eventType: string = CallNotification.State
+  public method: string = CallMethod.Begin
   public controlId: string = this.call.tag
-
-  get method(): string {
-    return 'calling.begin'
-  }
 
   get payload(): any {
     return {

--- a/packages/common/src/relay/calling/components/FaxReceive.ts
+++ b/packages/common/src/relay/calling/components/FaxReceive.ts
@@ -1,10 +1,8 @@
 import { BaseFax } from './BaseFax'
+import { CallMethod } from '../../../util/constants/relay'
 
 export class FaxReceive extends BaseFax {
-
-  get method(): string {
-    return 'calling.receive_fax'
-  }
+  public method: string = CallMethod.ReceiveFax
 
   get payload(): any {
     return {

--- a/packages/common/src/relay/calling/components/FaxSend.ts
+++ b/packages/common/src/relay/calling/components/FaxSend.ts
@@ -1,7 +1,9 @@
 import Call from '../Call'
 import { BaseFax } from './BaseFax'
+import { CallMethod } from '../../../util/constants/relay'
 
 export class FaxSend extends BaseFax {
+  public method: string = CallMethod.SendFax
 
   constructor(
     public call: Call,
@@ -10,10 +12,6 @@ export class FaxSend extends BaseFax {
     private _header: string = null
   ) {
     super(call)
-  }
-
-  get method(): string {
-    return 'calling.send_fax'
   }
 
   get payload(): any {

--- a/packages/common/src/relay/calling/components/Hangup.ts
+++ b/packages/common/src/relay/calling/components/Hangup.ts
@@ -1,18 +1,15 @@
 import { BaseComponent } from './BaseComponent'
-import { CallNotification, CallState } from '../../../util/constants/relay'
+import { CallNotification, CallState, CallMethod } from '../../../util/constants/relay'
 import Call from '../Call'
 import Event from '../Event'
 
 export class Hangup extends BaseComponent {
   public eventType: string = CallNotification.State
+  public method: string = CallMethod.End
   public controlId: string = this.call.tag
 
   constructor(public call: Call, public reason: string) {
     super(call)
-  }
-
-  get method(): string {
-    return 'calling.end'
   }
 
   get payload(): any {

--- a/packages/common/src/relay/calling/components/Play.ts
+++ b/packages/common/src/relay/calling/components/Play.ts
@@ -1,19 +1,16 @@
 import { Controllable } from './Controllable'
 import { IRelayCallingPlay } from '../../../util/interfaces'
-import { CallNotification, CallPlayState } from '../../../util/constants/relay'
+import { CallNotification, CallPlayState, CallMethod } from '../../../util/constants/relay'
 import Call from '../Call'
 import Event from '../Event'
 
 export class Play extends Controllable {
   public eventType: string = CallNotification.Play
+  public method: string = CallMethod.Play
   public controlId: string = this.controlId
 
   constructor(public call: Call, public play: IRelayCallingPlay[], public volumeValue: number = 0) {
     super(call)
-  }
-
-  get method(): string {
-    return 'calling.play'
   }
 
   get payload(): any {

--- a/packages/common/src/relay/calling/components/Prompt.ts
+++ b/packages/common/src/relay/calling/components/Prompt.ts
@@ -1,11 +1,12 @@
 import { Controllable } from './Controllable'
 import { IRelayCallingPlay, IRelayCallingCollect } from '../../../util/interfaces'
-import { CallNotification, CallPromptState } from '../../../util/constants/relay'
+import { CallNotification, CallPromptState, CallMethod } from '../../../util/constants/relay'
 import Call from '../Call'
 import Event from '../Event'
 
 export class Prompt extends Controllable {
   public eventType: string = CallNotification.Collect
+  public method: string = CallMethod.PlayAndCollect
   public controlId: string = this.controlId
 
   public type: string
@@ -20,10 +21,6 @@ export class Prompt extends Controllable {
     public volumeValue: number = 0
   ) {
     super(call)
-  }
-
-  get method(): string {
-    return 'calling.play_and_collect'
   }
 
   get payload(): any {

--- a/packages/common/src/relay/calling/components/Record.ts
+++ b/packages/common/src/relay/calling/components/Record.ts
@@ -1,11 +1,12 @@
 import { Controllable } from './Controllable'
-import { CallNotification, CallRecordState } from '../../../util/constants/relay'
+import { CallNotification, CallRecordState, CallMethod } from '../../../util/constants/relay'
 import Call from '../Call'
 import Event from '../Event'
 import { IRelayCallingRecord } from '../../../util/interfaces'
 
 export class Record extends Controllable {
   public eventType: string = CallNotification.Record
+  public method: string = CallMethod.Record
   public controlId: string = this.controlId
 
   public url: string
@@ -14,10 +15,6 @@ export class Record extends Controllable {
 
   constructor(public call: Call, public record: IRelayCallingRecord) {
     super(call)
-  }
-
-  get method(): string {
-    return 'calling.record'
   }
 
   get payload(): any {

--- a/packages/common/src/relay/calling/components/SendDigits.ts
+++ b/packages/common/src/relay/calling/components/SendDigits.ts
@@ -1,18 +1,15 @@
 import { BaseComponent } from './BaseComponent'
-import { CallNotification, SendDigitsState } from '../../../util/constants/relay'
+import { CallNotification, SendDigitsState, CallMethod } from '../../../util/constants/relay'
 import Call from '../Call'
 import Event from '../Event'
 
 export class SendDigits extends BaseComponent {
   public eventType: string = CallNotification.SendDigits
+  public method: string = CallMethod.SendDigits
   public controlId: string = this.controlId
 
   constructor(public call: Call, public digits: string) {
     super(call)
-  }
-
-  get method(): string {
-    return 'calling.send_digits'
   }
 
   get payload(): any {

--- a/packages/common/src/relay/calling/components/Tap.ts
+++ b/packages/common/src/relay/calling/components/Tap.ts
@@ -1,19 +1,16 @@
 import { Controllable } from './Controllable'
 import { IRelayCallingTapTap, IRelayCallingTapDevice } from '../../../util/interfaces'
-import { CallNotification, CallTapState } from '../../../util/constants/relay'
+import { CallNotification, CallTapState, CallMethod } from '../../../util/constants/relay'
 import Call from '../Call'
 import Event from '../Event'
 
 export class Tap extends Controllable {
   public eventType: string = CallNotification.Tap
+  public method: string = CallMethod.Tap
   public controlId: string = this.controlId
 
   constructor(public call: Call, public tap: IRelayCallingTapTap, public device: IRelayCallingTapDevice) {
     super(call)
-  }
-
-  get method(): string {
-    return 'calling.tap'
   }
 
   get payload(): any {

--- a/packages/common/src/services/BroadcastHandler.ts
+++ b/packages/common/src/services/BroadcastHandler.ts
@@ -1,16 +1,7 @@
-import BaseSession from '../BaseSession'
 import logger from '../util/logger'
-import RelayClient from '../../../node/src/relay/'
 import VertoHandler from '../webrtc/VertoHandler'
-import { CallNotification } from '../util/constants/relay'
 
-/* tslint:disable-next-line */
-export default function BroadcastHandler(session: BaseSession, broadcastParams: any): void;
-/* tslint:disable-next-line */
-export default function BroadcastHandler(session: RelayClient, broadcastParams: any): void;
-
-/* tslint:disable-next-line */
-export default function BroadcastHandler(session: any, broadcastParams: any): void {
+export default (session: any, broadcastParams: any): void => {
   const { protocol, event, params } = broadcastParams
   const { event_type, node_id } = params
 
@@ -18,33 +9,15 @@ export default function BroadcastHandler(session: any, broadcastParams: any): vo
     return logger.error('Session protocol mismatch.')
   }
 
-  const _switchOnEventType = () => {
-    switch (event_type) {
-      case CallNotification.State:
-      case CallNotification.Receive:
-      case CallNotification.Connect:
-      case CallNotification.Record:
-      case CallNotification.Play:
-      case CallNotification.Collect:
-      case CallNotification.Fax:
-      case CallNotification.Detect:
-      case CallNotification.Tap:
-      case CallNotification.SendDigits:
-        session.calling.notificationHandler(params)
-        break
-      case 'webrtc.message':
+  switch (event) {
+    case 'queuing.relay.events':
+      if (event_type === 'webrtc.message') {
         const handler = new VertoHandler(session)
         handler.nodeId = node_id
         handler.handleMessage(params.params)
-        break
-      default:
-        return logger.error(`Unknown notification type: ${event_type}`)
-    }
-  }
-
-  switch (event) {
-    case 'queuing.relay.events':
-      _switchOnEventType()
+      } else {
+        session.calling.notificationHandler(params)
+      }
       break
     case 'queuing.relay.tasks':
       session.tasking.notificationHandler(params)

--- a/packages/common/src/util/constants/relay.ts
+++ b/packages/common/src/util/constants/relay.ts
@@ -53,6 +53,21 @@ export enum CallNotification {
   SendDigits = 'calling.call.send_digits',
 }
 
+export enum CallMethod {
+  Answer = 'calling.answer',
+  Begin = 'calling.begin',
+  Connect = 'calling.connect',
+  End = 'calling.end',
+  Record = 'calling.record',
+  Play = 'calling.play',
+  PlayAndCollect = 'calling.play_and_collect',
+  ReceiveFax = 'calling.receive_fax',
+  SendFax = 'calling.send_fax',
+  Detect = 'calling.detect',
+  Tap = 'calling.tap',
+  SendDigits = 'calling.send_digits',
+}
+
 export enum SendDigitsState {
   Finished = 'finished',
 }


### PR DESCRIPTION
Small review to use constants instead of strings in Calling components.
Default `queuing.relay.events` to Calling namespace if not webrtc-related.