### PR TITLE
JS SDK fix es6 build

### DIFF
--- a/packages/common/src/util/logger.ts
+++ b/packages/common/src/util/logger.ts
@@ -1,6 +1,4 @@
 import log from 'loglevel'
-
-// const log = require('loglevel')
 const datetime = () => new Date().toISOString().replace('T', ' ').replace('Z', '')
 const logger = log.getLogger('signalwire')
 

--- a/packages/common/src/util/logger.ts
+++ b/packages/common/src/util/logger.ts
@@ -1,4 +1,6 @@
-const log = require('loglevel')
+import log from 'loglevel'
+
+// const log = require('loglevel')
 const datetime = () => new Date().toISOString().replace('T', ' ').replace('Z', '')
 const logger = log.getLogger('signalwire')
 

--- a/packages/common/tests/setup/browsers.ts
+++ b/packages/common/tests/setup/browsers.ts
@@ -1,21 +1,8 @@
 import * as webrtcMocks from './webrtcMocks'
 
-if (typeof window !== 'undefined') {
-  Object.defineProperties(window, {
-    RTCPeerConnection: {
-      value: () => {
-        return {
-          close: () => { },
-          addTrack: () => { },
-          createOffer: () => { },
-          createAnswer: () => { },
-          setLocalDescription: () => { },
-          setRemoteDescription: () => { },
-          addEventListener: (event: string, cb: Function) => { },
-        }
-      }
-    }
-  })
+if (typeof RTCPeerConnection === 'undefined') {
+  // @ts-ignore
+  global.RTCPeerConnection = webrtcMocks.RTCPeerConnectionMock
 }
 
 if (typeof MediaStream === 'undefined') {

--- a/packages/common/tests/setup/webrtcMocks.ts
+++ b/packages/common/tests/setup/webrtcMocks.ts
@@ -1,47 +1,48 @@
 import { v4 as uuidv4 } from 'uuid'
+
 class MediaStreamMock implements MediaStream {
   _tracks: MediaStreamTrack[] = []
-  active: boolean;
-  id: string;
+  active: boolean
+  id: string
 
-  onactive: (this: MediaStream, ev: Event) => any;
+  onactive: (this: MediaStream, ev: Event) => any
 
-  onaddtrack: (this: MediaStream, ev: MediaStreamTrackEvent) => any;
+  onaddtrack: (this: MediaStream, ev: MediaStreamTrackEvent) => any
 
-  oninactive: (this: MediaStream, ev: Event) => any;
+  oninactive: (this: MediaStream, ev: Event) => any
 
-  onremovetrack: (this: MediaStream, ev: MediaStreamTrackEvent) => any;
+  onremovetrack: (this: MediaStream, ev: MediaStreamTrackEvent) => any
 
   addTrack(track: MediaStreamTrack) {
     this._tracks.push(track)
   }
 
   clone(): MediaStream {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.')
   }
 
   getTrackById(trackId: any): MediaStreamTrack {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.')
   }
 
   removeTrack(track: any) {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.')
   }
 
   stop() {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.')
   }
 
   addEventListener(type: any, listener: any, options?: any) {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.')
   }
 
   removeEventListener(type: any, listener: any, options?: any) {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.')
   }
 
   dispatchEvent(event: Event): boolean {
-    throw new Error("Method not implemented.");
+    throw new Error("Method not implemented.")
   }
 
   getTracks() {
@@ -58,39 +59,39 @@ class MediaStreamMock implements MediaStream {
 }
 
 class MediaStreamTrackMock implements MediaStreamTrack {
-  enabled: boolean = true;
-  id: string = uuidv4();
-  isolated: boolean;
-  kind: string;
-  label: string = 'Track Label';
-  muted: boolean;
-  readonly: boolean;
-  readyState: MediaStreamTrackState;
-  remote: boolean;
-  onended: (this: MediaStreamTrack, ev: MediaStreamErrorEvent) => any;
-  onisolationchange: (this: MediaStreamTrack, ev: Event) => any;
-  onmute: (this: MediaStreamTrack, ev: Event) => any;
-  onoverconstrained: (this: MediaStreamTrack, ev: MediaStreamErrorEvent) => any;
-  onunmute: (this: MediaStreamTrack, ev: Event) => any;
+  enabled: boolean = true
+  id: string = uuidv4()
+  isolated: boolean
+  kind: string
+  label: string = 'Track Label'
+  muted: boolean
+  readonly: boolean
+  readyState: MediaStreamTrackState
+  remote: boolean
+  onended: (this: MediaStreamTrack, ev: MediaStreamErrorEvent) => any
+  onisolationchange: (this: MediaStreamTrack, ev: Event) => any
+  onmute: (this: MediaStreamTrack, ev: Event) => any
+  onoverconstrained: (this: MediaStreamTrack, ev: MediaStreamErrorEvent) => any
+  onunmute: (this: MediaStreamTrack, ev: Event) => any
 
   applyConstraints(constraints: any): Promise<void> {
-    throw new Error("Method not implemented.");
+    throw new Error("Method not implemented.")
   }
 
   clone(): MediaStreamTrack {
-    throw new Error("Method not implemented.");
+    throw new Error("Method not implemented.")
   }
 
   getCapabilities(): MediaTrackCapabilities {
-    throw new Error("Method not implemented.");
+    throw new Error("Method not implemented.")
   }
 
   getConstraints(): MediaTrackConstraints {
-    throw new Error("Method not implemented.");
+    throw new Error("Method not implemented.")
   }
 
   getSettings(): MediaTrackSettings {
-    throw new Error("Method not implemented.");
+    throw new Error("Method not implemented.")
   }
 
   stop() {
@@ -99,19 +100,168 @@ class MediaStreamTrackMock implements MediaStreamTrack {
   }
 
   addEventListener(type: any, listener: any, options?: any) {
-    // throw new Error("Method not implemented.");
+    // throw new Error("Method not implemented.")
   }
 
   removeEventListener(type: any, listener: any, options?: any) {
-    // throw new Error("Method not implemented.");
+    // throw new Error("Method not implemented.")
   }
 
   dispatchEvent(event: Event): boolean {
-    throw new Error("Method not implemented.");
+    throw new Error("Method not implemented.")
+  }
+}
+
+class RTCRtpSenderMock implements RTCRtpSender {
+  dtmf: RTCDTMFSender
+  rtcpTransport: RTCDtlsTransport
+  track: MediaStreamTrack
+  transport: RTCDtlsTransport
+  getParameters(): RTCRtpSendParameters
+  getParameters(): RTCRtpParameters
+  getParameters(): any {
+    throw new Error('Method not implemented.')
+  }
+  getStats(): Promise<RTCStatsReport> {
+    throw new Error('Method not implemented.')
+  }
+  replaceTrack(withTrack: MediaStreamTrack): Promise<void>
+  replaceTrack(withTrack: MediaStreamTrack): Promise<void>
+  replaceTrack(withTrack: any): any {
+    throw new Error('Method not implemented.')
+  }
+  setParameters(parameters: RTCRtpSendParameters): Promise<void>
+  setParameters(parameters?: RTCRtpParameters): Promise<void>
+  setParameters(parameters?: any): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+  setStreams(...streams: MediaStream[]): void {
+    throw new Error('Method not implemented.')
+  }
+}
+
+class RTCPeerConnectionMock implements RTCPeerConnection {
+  canTrickleIceCandidates: boolean
+  connectionState: RTCPeerConnectionState
+  currentLocalDescription: RTCSessionDescription
+  currentRemoteDescription: RTCSessionDescription
+  iceConnectionState: RTCIceConnectionState
+  iceGatheringState: RTCIceGatheringState
+  idpErrorInfo: string
+  idpLoginUrl: string
+  localDescription: RTCSessionDescription
+  onconnectionstatechange: (this: RTCPeerConnection, ev: Event) => any
+  ondatachannel: (this: RTCPeerConnection, ev: RTCDataChannelEvent) => any
+  onicecandidate: (this: RTCPeerConnection, ev: RTCPeerConnectionIceEvent) => any
+  onicecandidateerror: (this: RTCPeerConnection, ev: RTCPeerConnectionIceErrorEvent) => any
+  oniceconnectionstatechange: (this: RTCPeerConnection, ev: Event) => any
+  onicegatheringstatechange: (this: RTCPeerConnection, ev: Event) => any
+  onnegotiationneeded: (this: RTCPeerConnection, ev: Event) => any
+  onsignalingstatechange: (this: RTCPeerConnection, ev: Event) => any
+  onstatsended: (this: RTCPeerConnection, ev: RTCStatsEvent) => any
+  ontrack: (this: RTCPeerConnection, ev: RTCTrackEvent) => any
+  peerIdentity: Promise<RTCIdentityAssertion>
+  pendingLocalDescription: RTCSessionDescription
+  pendingRemoteDescription: RTCSessionDescription
+  remoteDescription: RTCSessionDescription
+  sctp: RTCSctpTransport
+  signalingState: RTCSignalingState
+  // addIceCandidate(candidate: RTCIceCandidateInit | RTCIceCandidate): Promise<void>
+  // addIceCandidate(candidate?: RTCIceCandidateInit | RTCIceCandidate): Promise<void>
+  // addIceCandidate(candidate: RTCIceCandidateInit | RTCIceCandidate, successCallback: () => void, failureCallback: RTCPeerConnectionErrorCallback): Promise<void>
+  addIceCandidate(candidate?: RTCIceCandidateInit | RTCIceCandidate): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+  addTrack(track: MediaStreamTrack, ...streams: MediaStream[]): RTCRtpSender {
+    // throw new Error('Method not implemented.')
+    return new RTCRtpSenderMock()
+  }
+  addTransceiver(trackOrKind: string | MediaStreamTrack, init?: RTCRtpTransceiverInit): RTCRtpTransceiver {
+    throw new Error('Method not implemented.')
+  }
+  close() {
+    throw new Error('Method not implemented.')
+  }
+  createAnswer(options?: RTCOfferOptions): Promise<RTCSessionDescriptionInit>
+  createAnswer(options?: RTCAnswerOptions): Promise<RTCSessionDescriptionInit>
+  createAnswer(successCallback: RTCSessionDescriptionCallback, failureCallback: RTCPeerConnectionErrorCallback): Promise<void>
+  createAnswer(successCallback?: any, failureCallback?: any): Promise<RTCSessionDescriptionInit | void> {
+    throw new Error('Method not implemented.')
+  }
+  createDataChannel(label: string, dataChannelDict?: RTCDataChannelInit): RTCDataChannel
+  createDataChannel(label: string, dataChannelDict?: RTCDataChannelInit): RTCDataChannel
+  createDataChannel(label: any, dataChannelDict?: any): RTCDataChannel {
+    throw new Error('Method not implemented.')
+  }
+  createOffer(options?: RTCOfferOptions): Promise<RTCSessionDescriptionInit>
+  createOffer(options?: RTCOfferOptions): Promise<RTCSessionDescriptionInit>
+  createOffer(successCallback: RTCSessionDescriptionCallback, failureCallback: RTCPeerConnectionErrorCallback, options?: RTCOfferOptions): Promise<void>
+  createOffer(successCallback?: any, failureCallback?: any, options?: any): Promise<RTCSessionDescriptionInit | void> {
+    throw new Error('Method not implemented.')
+  }
+  getConfiguration(): RTCConfiguration {
+    throw new Error('Method not implemented.')
+  }
+  getIdentityAssertion(): Promise<string> {
+    throw new Error('Method not implemented.')
+  }
+  getReceivers(): RTCRtpReceiver[] {
+    throw new Error('Method not implemented.')
+  }
+  getSenders(): RTCRtpSender[] {
+    throw new Error('Method not implemented.')
+  }
+  getStats(selector?: MediaStreamTrack): Promise<RTCStatsReport>
+  getStats(selector?: MediaStreamTrack): Promise<RTCStatsReport>
+  getStats(selector: MediaStreamTrack, successCallback: RTCStatsCallback, failureCallback: RTCPeerConnectionErrorCallback): Promise<void>
+  getStats(selector?: any, successCallback?: any, failureCallback?: any): Promise<RTCStatsReport | void> {
+    throw new Error('Method not implemented.')
+  }
+  getTransceivers(): RTCRtpTransceiver[] {
+    throw new Error('Method not implemented.')
+  }
+  removeTrack(sender: RTCRtpSender): void
+  removeTrack(sender: RTCRtpSender): void
+  removeTrack(sender: any) {
+    throw new Error('Method not implemented.')
+  }
+  setConfiguration(configuration: RTCConfiguration): void
+  setConfiguration(configuration: RTCConfiguration): void
+  setConfiguration(configuration: any) {
+    throw new Error('Method not implemented.')
+  }
+  setIdentityProvider(provider: string, options?: RTCIdentityProviderOptions): void {
+    throw new Error('Method not implemented.')
+  }
+  setLocalDescription(description: RTCSessionDescriptionInit): Promise<void>
+  setLocalDescription(description: RTCSessionDescriptionInit): Promise<void>
+  setLocalDescription(description: RTCSessionDescriptionInit, successCallback: () => void, failureCallback: RTCPeerConnectionErrorCallback): Promise<void>
+  setLocalDescription(description: any, successCallback?: any, failureCallback?: any): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+  setRemoteDescription(description: RTCSessionDescriptionInit): Promise<void>
+  setRemoteDescription(description: RTCSessionDescriptionInit): Promise<void>
+  setRemoteDescription(description: RTCSessionDescriptionInit, successCallback: () => void, failureCallback: RTCPeerConnectionErrorCallback): Promise<void>
+  setRemoteDescription(description: any, successCallback?: any, failureCallback?: any): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+  addEventListener<K extends 'connectionstatechange' | 'datachannel' | 'icecandidate' | 'icecandidateerror' | 'iceconnectionstatechange' | 'icegatheringstatechange' | 'negotiationneeded' | 'signalingstatechange' | 'statsended' | 'track'>(type: K, listener: (this: RTCPeerConnection, ev: RTCPeerConnectionEventMap[K]) => void, options?: boolean | AddEventListenerOptions): void
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void
+  addEventListener(type: any, listener: any, options?: any) {
+    // throw new Error('Method not implemented.')
+  }
+  removeEventListener<K extends 'connectionstatechange' | 'datachannel' | 'icecandidate' | 'icecandidateerror' | 'iceconnectionstatechange' | 'icegatheringstatechange' | 'negotiationneeded' | 'signalingstatechange' | 'statsended' | 'track'>(type: K, listener: (this: RTCPeerConnection, ev: RTCPeerConnectionEventMap[K]) => void, options?: boolean | EventListenerOptions): void
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void
+  removeEventListener(type: any, listener: any, options?: any) {
+    throw new Error('Method not implemented.')
+  }
+  dispatchEvent(event: Event): boolean {
+    throw new Error('Method not implemented.')
   }
 }
 
 export {
   MediaStreamMock,
-  MediaStreamTrackMock
+  MediaStreamTrackMock,
+  RTCPeerConnectionMock
 }

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
+## [1.2.4-beta.2] - 2019-12-02
+### Changed
+- Support Rollup.js as module bundler - Minor fix into Es6 export version
+
+### Security
+- Update devDependencies
+
 ## [1.2.4-beta.1] - 2019-11-12
 ### Added
 - WebRTC video improvements (increase bitrate)

--- a/packages/js/index.ts
+++ b/packages/js/index.ts
@@ -2,7 +2,7 @@ import Relay from './src/SignalWire'
 import Verto from './src/Verto'
 import { setAgentName } from '../common/src/messages/blade/Connect'
 
-export const VERSION = '1.2.4-beta.1'
+export const VERSION = '1.2.4-beta.2'
 setAgentName(`JavaScript SDK/${VERSION}`)
 
 export {

--- a/packages/js/jest.config.js
+++ b/packages/js/jest.config.js
@@ -1,6 +1,11 @@
 module.exports = {
 	moduleFileExtensions: [ 'ts', 'js' ],
 	rootDir: '../',
+	globals: {
+		'ts-jest': {
+			tsConfig: '<rootDir>/js/tsconfig.json'
+		}
+	},
 	coverageDirectory: '<rootDir>/js/coverage',
 	testMatch: [
 		'<rootDir>/(common|js)/tests/**/*.test.(ts|js)'

--- a/packages/js/package-lock.json
+++ b/packages/js/package-lock.json
@@ -4537,9 +4537,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -9343,9 +9343,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.7.tgz",
-      "integrity": "sha512-4sXQDzmdnoXiO+xvmTzQsfIiwrjUCSA95rSP4SEd8tDb51W2TiDOlL76Hl+Kw0Ie42PSItCW8/t6pBNCF2R48A==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.1.tgz",
+      "integrity": "sha512-pnOF7jY82wdIhATVn87uUY/FHU+MDUdPLkmGFvGoclQmeu229eTkbG5gjGGBi3R7UuYYSEeYXY/TTY5j2aym2g==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/packages/js/package-lock.json
+++ b/packages/js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalwire/js",
-  "version": "1.2.4-beta.1",
+  "version": "1.2.4-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalwire/js",
-  "version": "1.2.4-beta.1",
+  "version": "1.2.4-beta.2",
   "description": "Relay SDK for JavaScript to connect to SignalWire.",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "main": "dist/index.min.js",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Call `disconnect()` method.
 
+### Security
+- Update devDependencies
+
 ## [2.3.1] - 2019-11-01
 ### Fixed
 - Relay client reconnection issue after network failure/reset.

--- a/packages/node/jest.config.js
+++ b/packages/node/jest.config.js
@@ -1,6 +1,11 @@
 module.exports = {
   moduleFileExtensions: [ 'ts', 'js' ],
   rootDir: '../',
+  globals: {
+    'ts-jest': {
+      tsConfig: '<rootDir>/node/tsconfig.json'
+    }
+  },
   coverageDirectory: '<rootDir>/node/coverage',
   testPathIgnorePatterns: [
     '/node_modules/',

--- a/packages/node/package-lock.json
+++ b/packages/node/package-lock.json
@@ -2845,9 +2845,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -5940,9 +5940,9 @@
       "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg=="
     },
     "uglify-js": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.7.tgz",
-      "integrity": "sha512-4sXQDzmdnoXiO+xvmTzQsfIiwrjUCSA95rSP4SEd8tDb51W2TiDOlL76Hl+Kw0Ie42PSItCW8/t6pBNCF2R48A==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.1.tgz",
+      "integrity": "sha512-pnOF7jY82wdIhATVn87uUY/FHU+MDUdPLkmGFvGoclQmeu229eTkbG5gjGGBi3R7UuYYSEeYXY/TTY5j2aym2g==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -3,7 +3,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Security
+- Update devDependencies
+
 ## [1.0.1] - 2019-10-15
 ### Added
 - New methods to manage devices: `getDevices()`, `getVideoDevices()`, `getAudioInDevices()`, `getAudioOutDevices()`.

--- a/packages/react-native/jest.config.js
+++ b/packages/react-native/jest.config.js
@@ -1,6 +1,11 @@
 module.exports = {
 	moduleFileExtensions: [ 'ts', 'js' ],
 	rootDir: '../',
+	globals: {
+		'ts-jest': {
+			tsConfig: '<rootDir>/react-native/tsconfig.json'
+		}
+	},
 	coverageDirectory: '<rootDir>/react-native/coverage',
 	testMatch: [
 		'<rootDir>/(common|react-native)/tests/**/*.test.(ts|js)'

--- a/packages/react-native/package-lock.json
+++ b/packages/react-native/package-lock.json
@@ -2531,9 +2531,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.3.tgz",
-      "integrity": "sha512-VupOxR91xcGojfINrzMqrvlyYbBs39sXIrWa7YdaQWeBudOlvKEGvCczMfJPgnuwHE/zyH1M6J+IUP6cgDVyxg==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -5661,14 +5661,23 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.1.tgz",
+      "integrity": "sha512-pnOF7jY82wdIhATVn87uUY/FHU+MDUdPLkmGFvGoclQmeu229eTkbG5gjGGBi3R7UuYYSEeYXY/TTY5j2aym2g==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "union-value": {


### PR DESCRIPTION
This PR includes:

- Fix to use the JS SDK Es6 version with [Rollup](https://rollupjs.org/guide/en/) and tree-shaking
- 3 dev vulnerability issues in Node/JS/RN packages
- Use same JS environment to run ts-jest 