### PR TITLE
Try reconnecting if the socket has never been connected

### DIFF
--- a/packages/common/src/BaseSession.ts
+++ b/packages/common/src/BaseSession.ts
@@ -32,8 +32,8 @@ export default abstract class BaseSession {
   protected _reconnectTimeout: any
   protected _reconnectDelay: number = 5000
   protected _autoReconnect: boolean = true
+  protected _idle: boolean = false
 
-  private _idle: boolean = false
   private _executeQueue: { resolve?: Function, msg: any}[] = []
   private _pong: boolean
 

--- a/packages/common/src/BaseSession.ts
+++ b/packages/common/src/BaseSession.ts
@@ -29,8 +29,9 @@ export default abstract class BaseSession {
   protected _jwtAuth: boolean = false
   protected _doKeepAlive: boolean = false
   protected _keepAliveTimeout: any
+  protected _reconnectTimeout: any
   protected _reconnectDelay: number = 5000
-  protected _autoReconnect: boolean = false
+  protected _autoReconnect: boolean = true
 
   private _idle: boolean = false
   private _executeQueue: { resolve?: Function, msg: any}[] = []
@@ -41,8 +42,7 @@ export default abstract class BaseSession {
       throw new Error('Invalid init options')
     }
     this._onSocketOpen = this._onSocketOpen.bind(this)
-    this._onSocketClose = this._onSocketClose.bind(this)
-    this._onSocketError = this._onSocketError.bind(this)
+    this._onSocketCloseOrError = this._onSocketCloseOrError.bind(this)
     this._onSocketMessage = this._onSocketMessage.bind(this)
     this._handleLoginError = this._handleLoginError.bind(this)
     this._checkTokenExpiration = this._checkTokenExpiration.bind(this)
@@ -141,6 +141,7 @@ export default abstract class BaseSession {
    * @return void
    */
   async disconnect() {
+    clearTimeout(this._reconnectTimeout)
     this.subscriptions = {}
     this._autoReconnect = false
     this.relayProtocol = null
@@ -244,10 +245,11 @@ export default abstract class BaseSession {
   }
 
   /**
-   * Callback when the ws connection is going to close
+   * Callback when the ws connection is going to close or get an error
    * @return void
    */
-  protected _onSocketClose() {
+  protected _onSocketCloseOrError(event: any): void {
+    logger.error(`Socket ${event.type} ${event.message}`)
     if (this.relayProtocol) {
       deRegisterAll(this.relayProtocol)
     }
@@ -262,16 +264,8 @@ export default abstract class BaseSession {
       this.expiresAt = 0
     }
     if (this._autoReconnect) {
-      setTimeout(() => this.connect(), this._reconnectDelay)
+      this._reconnectTimeout = setTimeout(() => this.connect(), this._reconnectDelay)
     }
-  }
-
-  /**
-   * Callback when the ws connection give an error
-   * @return void
-   */
-  protected _onSocketError(error: Error) {
-    logger.error(error.message)
   }
 
   /**
@@ -344,8 +338,8 @@ export default abstract class BaseSession {
   private _attachListeners() {
     this._detachListeners()
     this.on(SwEvent.SocketOpen, this._onSocketOpen)
-    this.on(SwEvent.SocketClose, this._onSocketClose)
-    this.on(SwEvent.SocketError, this._onSocketError)
+    this.on(SwEvent.SocketClose, this._onSocketCloseOrError)
+    this.on(SwEvent.SocketError, this._onSocketCloseOrError)
     this.on(SwEvent.SocketMessage, this._onSocketMessage)
   }
 
@@ -355,8 +349,8 @@ export default abstract class BaseSession {
    */
   private _detachListeners() {
     this.off(SwEvent.SocketOpen, this._onSocketOpen)
-    this.off(SwEvent.SocketClose, this._onSocketClose)
-    this.off(SwEvent.SocketError, this._onSocketError)
+    this.off(SwEvent.SocketClose, this._onSocketCloseOrError)
+    this.off(SwEvent.SocketError, this._onSocketCloseOrError)
     this.off(SwEvent.SocketMessage, this._onSocketMessage)
   }
 

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -3,7 +3,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+### Fixed
+- Keep trying to reconnect WS in case of network failure - even if it never has been connected.
+
 ## [1.2.4-beta.2] - 2019-12-02
 ### Changed
 - Support Rollup.js as module bundler - Minor fix into Es6 export version

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.4] - 2019-12-04
 ### Fixed
 - Keep trying to reconnect WS in case of network failure - even if it never has been connected.
 

--- a/packages/js/index.ts
+++ b/packages/js/index.ts
@@ -2,7 +2,7 @@ import Relay from './src/SignalWire'
 import Verto from './src/Verto'
 import { setAgentName } from '../common/src/messages/blade/Connect'
 
-export const VERSION = '1.2.4-beta.2'
+export const VERSION = '1.2.4'
 setAgentName(`JavaScript SDK/${VERSION}`)
 
 export {

--- a/packages/js/package-lock.json
+++ b/packages/js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalwire/js",
-  "version": "1.2.4-beta.2",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalwire/js",
-  "version": "1.2.4-beta.2",
+  "version": "1.2.4",
   "description": "Relay SDK for JavaScript to connect to SignalWire.",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "main": "dist/index.min.js",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -6,6 +6,7 @@
   "main": "dist/index.min.js",
   "unpkg": "dist/index.min.js",
   "module": "dist/esm/js/index.js",
+  "types": "dist/esm/js/index.d.ts",
   "files": [
     "dist"
   ],

--- a/packages/js/src/Verto.ts
+++ b/packages/js/src/Verto.ts
@@ -40,6 +40,7 @@ export default class Verto extends BrowserSession {
   }
 
   protected async _onSocketOpen() {
+    this._idle = false
     const { login, password, passwd, userVariables } = this.options
     const msg = new Login(login, (password || passwd), this.sessionid, userVariables)
     const response = await this.execute(msg).catch(this._handleLoginError)

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Call `disconnect()` method.
 
+### Fixed
+- Keep trying to reconnect WS in case of network failure - even if it never has been connected.
+
 ### Security
 - Update devDependencies
 

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Keep trying to reconnect WS in case of network failure - even if it never has been connected.
+
 ### Security
 - Update devDependencies
 


### PR DESCRIPTION
This PR fixes the case when the SDKs can't init the WS connection the first time due to network failure (cert expired/network down) and doesn't keep trying to connect.