### PR TITLE
Filter device list before check for permission

### DIFF
--- a/packages/common/src/webrtc/helpers.ts
+++ b/packages/common/src/webrtc/helpers.ts
@@ -33,14 +33,14 @@ const _constraintsByKind = (kind: string = null): { audio: boolean, video: boole
  */
 const getDevices = async (kind: string = null): Promise<MediaDeviceInfo[]> => {
   let devices = await WebRTC.enumerateDevices().catch(error => [])
+  if (kind) {
+    devices = devices.filter((d: MediaDeviceInfo) => d.kind === kind)
+  }
   const invalid: boolean = devices.length && devices.every((d: MediaDeviceInfo) => (!d.deviceId || !d.label))
   if (invalid) {
     const stream = await WebRTC.getUserMedia(_constraintsByKind(kind))
     WebRTC.stopStream(stream)
     return getDevices(kind)
-  }
-  if (kind) {
-    devices = devices.filter((d: MediaDeviceInfo) => d.kind === kind)
   }
   const found = []
   devices = devices.filter(({ kind, groupId }: MediaDeviceInfo) => {

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fix `getVideoDevices()`, `getAudioInDevices()`, `getAudioOutDevices()` methods to avoid return a deviceList with empty labels.
+
 ## [1.2.4] - 2019-12-04
 ### Fixed
 - Keep trying to reconnect WS in case of network failure - even if it never has been connected.


### PR DESCRIPTION
This fix prevent return devices with empty labels due to lack of permission by the browser.