### PR TITLE
Release JS SDK v1.2.5

### DIFF
--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- ## [Unreleased] -->
 
+## [1.2.5] - 2020-01-14
+### Fixed
+- [Verto client fix] Reattach previous session in case of use the SDK from multiple tabs of the same browser.
+
 ## [1.2.5-beta.1] - 2019-12-19
 ### Added
 - Ability to set `googleMaxBitrate`, `googleMinBitrate` and `googleStartBitrate` values per Call.

--- a/packages/js/index.ts
+++ b/packages/js/index.ts
@@ -2,7 +2,7 @@ import Relay from './src/SignalWire'
 import Verto from './src/Verto'
 import { setAgentName } from '../common/src/messages/blade/Connect'
 
-export const VERSION = '1.2.5-beta.1'
+export const VERSION = '1.2.5'
 setAgentName(`JavaScript SDK/${VERSION}`)
 
 export {

--- a/packages/js/package-lock.json
+++ b/packages/js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalwire/js",
-  "version": "1.2.5-beta.1",
+  "version": "1.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalwire/js",
-  "version": "1.2.5-beta.1",
+  "version": "1.2.5",
   "description": "Relay SDK for JavaScript to connect to SignalWire.",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "main": "dist/index.min.js",

--- a/packages/js/src/Verto.ts
+++ b/packages/js/src/Verto.ts
@@ -42,6 +42,10 @@ export default class Verto extends BrowserSession {
   protected async _onSocketOpen() {
     this._idle = false
     const { login, password, passwd, userVariables } = this.options
+    if (this.sessionid) {
+      const sessidLogin = new Login(undefined, undefined, this.sessionid, undefined)
+      await this.execute(sessidLogin).catch(console.error)
+    }
     const msg = new Login(login, (password || passwd), this.sessionid, userVariables)
     const response = await this.execute(msg).catch(this._handleLoginError)
     if (response) {


### PR DESCRIPTION
This PR contains a fix for the Verto client only. 
If you open another tab while you already have a session with Verto, for some reason mod_verto requires a `login` attempt with _sessid_ only that will fail with "Authentication Required". 

After this "empty login" attempt the new tab will receive the `verto.attach` as normal to restore the previous session.