### PR TITLE
Fix getDevices to always return devices with deviceId and label

### DIFF
--- a/packages/common/src/webrtc/helpers.ts
+++ b/packages/common/src/webrtc/helpers.ts
@@ -35,8 +35,8 @@ const getDevices = async (kind: string = null): Promise<MediaDeviceInfo[]> => {
   if (kind) {
     devices = devices.filter((d: MediaDeviceInfo) => d.kind === kind)
   }
-  const invalid: boolean = devices.length && devices.every((d: MediaDeviceInfo) => (!d.deviceId || !d.label))
-  if (invalid) {
+  const valid: boolean = devices.length && devices.every((d: MediaDeviceInfo) => (d.deviceId && d.label))
+  if (!valid) {
     const stream = await WebRTC.getUserMedia(_constraintsByKind(kind))
     WebRTC.stopStream(stream)
     return getDevices(kind)

--- a/packages/common/tests/webrtc/helpers.test.ts
+++ b/packages/common/tests/webrtc/helpers.test.ts
@@ -73,6 +73,12 @@ describe('Helpers browser functions', () => {
   })
 
   describe('getDevices', () => {
+
+    beforeEach(() => {
+      // @ts-ignore
+      navigator.mediaDevices.getUserMedia.mockClear()
+    })
+
     it('should return the device list removing the duplicated', async done => {
       const devices = await getDevices()
       expect(devices).toHaveLength(5)
@@ -100,27 +106,56 @@ describe('Helpers browser functions', () => {
       done()
     })
 
-    describe('on safari without deviceId or label', () => {
-      const ENUMERATED_MEDIA_DEVICES_SAFARI = [
-        { 'deviceId': 'default', 'kind': 'audioinput', 'label': '', 'groupId': '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f' },
-        { 'deviceId': '', 'kind': 'audioinput', 'label': '', 'groupId': '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f' },
-        { 'deviceId': '', 'kind': 'audioinput', 'label': '', 'groupId': '67a612f4ac80c6c9854b50d664348e69b5a11421a0ba8d68e2c00f3539992b4c' },
+    describe('without camera permissions', () => {
+      const DEVICES_CAMERA_NO_LABELS = [
+        { 'deviceId': 'uuid', 'kind': 'audioinput', 'label': 'mic1', 'groupId': '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f' },
+        { 'deviceId': 'uuid', 'kind': 'audioinput', 'label': 'mic2', 'groupId': '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f' },
+        { 'deviceId': 'uuid', 'kind': 'audioinput', 'label': 'mic3', 'groupId': '67a612f4ac80c6c9854b50d664348e69b5a11421a0ba8d68e2c00f3539992b4c' },
 
-        { 'deviceId': 'default', 'kind': 'videoinput', 'label': '', 'groupId': '72e8ab9444144c3f8e04276a5801e520e83fc801702a6ef68e9e344083f6f6ce' },
-        { 'deviceId': '', 'kind': 'videoinput', 'label': '', 'groupId': '67a612f4ac80c6c9854b50d664348e69b5a11421a0ba8d68e2c00f3539992b4c' },
+        { 'deviceId': 'uuid', 'kind': 'videoinput', 'label': '', 'groupId': '72e8ab9444144c3f8e04276a5801e520e83fc801702a6ef68e9e344083f6f6ce' },
+        { 'deviceId': 'uuid', 'kind': 'videoinput', 'label': '', 'groupId': '67a612f4ac80c6c9854b50d664348e69b5a11421a0ba8d68e2c00f3539992b4c' },
 
-        { 'deviceId': 'default', 'kind': 'audiooutput', 'label': '', 'groupId': '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f' },
-        { 'deviceId': '', 'kind': 'audiooutput', 'label': '', 'groupId': '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f' },
+        { 'deviceId': 'uuid', 'kind': 'audiooutput', 'label': 'speaker1', 'groupId': '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f' },
+        { 'deviceId': 'uuid', 'kind': 'audiooutput', 'label': 'speaker2', 'groupId': '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f' },
       ]
-      it('should return the device list removing the duplicated', async done => {
+      it('should invoke getUserMedia to request camera permissions and return device list removing duplicates', async done => {
         // @ts-ignore
-        navigator.mediaDevices.enumerateDevices.mockResolvedValueOnce(ENUMERATED_MEDIA_DEVICES_SAFARI)
+        navigator.mediaDevices.enumerateDevices.mockResolvedValueOnce(DEVICES_CAMERA_NO_LABELS)
         const devices = await getDevices()
         expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1)
+        expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({ audio: true, video: true })
         expect(devices).toHaveLength(5)
         expect(devices[0].label).toEqual('Default - External Microphone (Built-in)')
+        expect(devices.every((d: MediaDeviceInfo) => (d.deviceId && d.label))).toBe(true)
         done()
       })
     })
+
+
+    describe('without microphone permissions', () => {
+      const DEVICES_MICROPHONE_NO_LABELS = [
+        { 'deviceId': 'uuid', 'kind': 'audioinput', 'label': '', 'groupId': '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f' },
+        { 'deviceId': 'uuid', 'kind': 'audioinput', 'label': '', 'groupId': '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f' },
+        { 'deviceId': 'uuid', 'kind': 'audioinput', 'label': '', 'groupId': '67a612f4ac80c6c9854b50d664348e69b5a11421a0ba8d68e2c00f3539992b4c' },
+
+        { 'deviceId': 'uuid', 'kind': 'videoinput', 'label': 'camera1', 'groupId': '72e8ab9444144c3f8e04276a5801e520e83fc801702a6ef68e9e344083f6f6ce' },
+        { 'deviceId': 'uuid', 'kind': 'videoinput', 'label': 'camera2', 'groupId': '67a612f4ac80c6c9854b50d664348e69b5a11421a0ba8d68e2c00f3539992b4c' },
+
+        { 'deviceId': 'uuid', 'kind': 'audiooutput', 'label': 'speaker1', 'groupId': '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f' },
+        { 'deviceId': 'uuid', 'kind': 'audiooutput', 'label': 'speaker2', 'groupId': '83ef347b97d14abd837e8c6dbb819c5be84cfe0756dd41455b375cfd4c0ddb4f' },
+      ]
+      it('should invoke getUserMedia to request microphone permissions and return device list removing duplicates', async done => {
+        // @ts-ignore
+        navigator.mediaDevices.enumerateDevices.mockResolvedValueOnce(DEVICES_MICROPHONE_NO_LABELS)
+        const devices = await getDevices()
+        expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1)
+        expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({ audio: true, video: true })
+        expect(devices).toHaveLength(5)
+        expect(devices[0].label).toEqual('Default - External Microphone (Built-in)')
+        expect(devices.every((d: MediaDeviceInfo) => (d.deviceId && d.label))).toBe(true)
+        done()
+      })
+    })
+
   })
 })

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -3,9 +3,11 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.6] - 2020-02-06
+### Fixed
+- Make sure `getDevices()` methods always return devices with both deviceId and label even if the browser does not have camera or microphone permissions
 ### Changed
-- Add TypeScript interface for WebRTC call object to include missing methods for TS users.
+- Add TypeScript interfaces for WebRTC call object to include missing methods.
 
 ## [1.2.5] - 2020-01-14
 ### Fixed

--- a/packages/js/index.ts
+++ b/packages/js/index.ts
@@ -2,7 +2,7 @@ import Relay from './src/SignalWire'
 import Verto from './src/Verto'
 import { setAgentName } from '../common/src/messages/blade/Connect'
 
-export const VERSION = '1.2.5'
+export const VERSION = '1.2.6'
 setAgentName(`JavaScript SDK/${VERSION}`)
 
 export {

--- a/packages/js/package-lock.json
+++ b/packages/js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalwire/js",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalwire/js",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Relay SDK for JavaScript to connect to SignalWire.",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "main": "dist/index.min.js",


### PR DESCRIPTION
Revert check on `deviceId` and `label`.

Closes #223 