### PR TITLE
Expose method to assure the webrtc devices 

### DIFF
--- a/packages/common/src/BrowserSession.ts
+++ b/packages/common/src/BrowserSession.ts
@@ -4,7 +4,7 @@ import { ICacheDevices, IAudioSettings, IVideoSettings, BroadcastParams, Subscri
 import { registerOnce, trigger } from './services/Handler'
 import { SwEvent, SESSION_ID } from './util/constants'
 import { State, DeviceType } from './webrtc/constants'
-import { getDevices, scanResolutions, removeUnsupportedConstraints, checkDeviceIdConstraints, destructSubscribeResponse, getUserMedia } from './webrtc/helpers'
+import { getDevices, scanResolutions, removeUnsupportedConstraints, checkDeviceIdConstraints, destructSubscribeResponse, getUserMedia, assureDeviceId } from './webrtc/helpers'
 import { findElementByType } from './util/helpers'
 import { Unsubscribe, Subscribe, Broadcast } from './messages/Verto'
 import { localStorage } from './util/storage/'
@@ -131,6 +131,10 @@ export default abstract class BrowserSession extends BaseSession {
       trigger(SwEvent.MediaError, error, this.uuid)
       return []
     })
+  }
+
+  assureDeviceId(id: string, label: string, kind: MediaDeviceInfo['kind']): Promise<string> {
+    return assureDeviceId(id, label, kind)
   }
 
   /**

--- a/packages/common/src/BrowserSession.ts
+++ b/packages/common/src/BrowserSession.ts
@@ -133,7 +133,7 @@ export default abstract class BrowserSession extends BaseSession {
     })
   }
 
-  assureDeviceId(id: string, label: string, kind: MediaDeviceInfo['kind']): Promise<string> {
+  validateDeviceId(id: string, label: string, kind: MediaDeviceInfo['kind']): Promise<string> {
     return assureDeviceId(id, label, kind)
   }
 

--- a/packages/common/src/webrtc/helpers.ts
+++ b/packages/common/src/webrtc/helpers.ts
@@ -30,7 +30,7 @@ const _constraintsByKind = (kind: string = null): { audio: boolean, video: boole
  * If 'deviceId' or 'label' are missing it means we are on Safari (macOS or iOS)
  * so we must request permissions to the user and then refresh the device list.
  */
-const getDevices = async (kind: string = null): Promise<MediaDeviceInfo[]> => {
+const getDevices = async (kind: string = null, fullList: boolean = false): Promise<MediaDeviceInfo[]> => {
   let devices = await WebRTC.enumerateDevices().catch(error => [])
   if (kind) {
     devices = devices.filter((d: MediaDeviceInfo) => d.kind === kind)
@@ -40,6 +40,9 @@ const getDevices = async (kind: string = null): Promise<MediaDeviceInfo[]> => {
     const stream = await WebRTC.getUserMedia(_constraintsByKind(kind))
     WebRTC.stopStream(stream)
     return getDevices(kind)
+  }
+  if (fullList === true) {
+    return devices
   }
   const found = []
   devices = devices.filter(({ kind, groupId }: MediaDeviceInfo) => {

--- a/packages/common/src/webrtc/helpers.ts
+++ b/packages/common/src/webrtc/helpers.ts
@@ -108,15 +108,7 @@ const getMediaConstraints = async (options: CallOptions): Promise<MediaStreamCon
 }
 
 const assureDeviceId = async (id: string, label: string, kind: MediaDeviceInfo['kind']): Promise<string> => {
-  const devices = await WebRTC.enumerateDevices()
-    .catch(error => [])
-    .then(all => all.filter((d: MediaDeviceInfo) => d.kind === kind))
-  const invalid: boolean = devices.length && devices.every((d: MediaDeviceInfo) => (!d.deviceId || !d.label))
-  if (invalid) {
-    const stream = await WebRTC.getUserMedia(_constraintsByKind(kind))
-    WebRTC.stopStream(stream)
-    return assureDeviceId(id, label, kind)
-  }
+  const devices = await getDevices(kind, true)
   for (let i = 0; i < devices.length; i++) {
     const { deviceId, label: deviceLabel } = devices[i]
     if (id === deviceId || label === deviceLabel) {

--- a/packages/common/tests/webrtc/helpers.test.ts
+++ b/packages/common/tests/webrtc/helpers.test.ts
@@ -79,9 +79,15 @@ describe('Helpers browser functions', () => {
       navigator.mediaDevices.getUserMedia.mockClear()
     })
 
-    it('should return the device list removing the duplicated', async done => {
+    it('should return the device list removing the duplicates', async done => {
       const devices = await getDevices()
       expect(devices).toHaveLength(5)
+      done()
+    })
+
+    it('should return the full device list', async done => {
+      const devices = await getDevices(null, true)
+      expect(devices).toHaveLength(7)
       done()
     })
 

--- a/packages/common/tests/webrtc/helpers.test.ts
+++ b/packages/common/tests/webrtc/helpers.test.ts
@@ -1,5 +1,5 @@
 import { findElementByType } from '../../../common/src/util/helpers'
-import { sdpStereoHack, sdpMediaOrderHack, sdpBitrateHack, getDevices } from '../../src/webrtc/helpers'
+import { sdpStereoHack, sdpMediaOrderHack, sdpBitrateHack, getDevices, assureDeviceId } from '../../src/webrtc/helpers'
 
 describe('Helpers browser functions', () => {
   describe('findElementByType', () => {
@@ -161,6 +161,49 @@ describe('Helpers browser functions', () => {
         expect(devices.every((d: MediaDeviceInfo) => (d.deviceId && d.label))).toBe(true)
         done()
       })
+    })
+
+  })
+
+  describe('assureDeviceId', () => {
+
+    beforeEach(() => {
+      // @ts-ignore
+      navigator.mediaDevices.enumerateDevices.mockClear()
+    })
+
+    it('should return the deviceId if the device is available', async done => {
+      // See setup/browser.ts for these values.
+      const deviceId = await assureDeviceId('2060bf50ab9c29c12598bf4eafeafa71d4837c667c7c172bb4407ec6c5150206', 'FaceTime HD Camera', 'videoinput')
+      expect(deviceId).toEqual('2060bf50ab9c29c12598bf4eafeafa71d4837c667c7c172bb4407ec6c5150206')
+      expect(navigator.mediaDevices.enumerateDevices).toHaveBeenCalledTimes(1)
+      done()
+    })
+
+    it('should return null if the device is no longer available', async done => {
+      const NEW_DEVICE_LIST = [
+        { 'deviceId': 'uuid', 'kind': 'videoinput', 'label': 'camera1', 'groupId': '72e8ab9444144c3f8e04276a5801e520e83fc801702a6ef68e9e344083f6f6ce' },
+        { 'deviceId': 'uuid', 'kind': 'videoinput', 'label': 'camera2', 'groupId': '67a612f4ac80c6c9854b50d664348e69b5a11421a0ba8d68e2c00f3539992b4c' }
+      ]
+      // @ts-ignore
+      navigator.mediaDevices.enumerateDevices.mockResolvedValueOnce(NEW_DEVICE_LIST)
+      const deviceId = await assureDeviceId('2060bf50ab9c29c12598bf4eafeafa71d4837c667c7c172bb4407ec6c5150206', 'FaceTime HD Camera', 'videoinput')
+      expect(deviceId).toBeNull()
+      expect(navigator.mediaDevices.enumerateDevices).toHaveBeenCalledTimes(1)
+      done()
+    })
+
+    it('should recognize the device by its label', async done => {
+      const NEW_DEVICE_LIST = [
+        { 'deviceId': 'uuid', 'kind': 'videoinput', 'label': 'camera1', 'groupId': '72e8ab9444144c3f8e04276a5801e520e83fc801702a6ef68e9e344083f6f6ce' },
+        { 'deviceId': 'new-uuid', 'kind': 'videoinput', 'label': 'FaceTime HD Camera', 'groupId': '67a612f4ac80c6c9854b50d664348e69b5a11421a0ba8d68e2c00f3539992b4c' }
+      ]
+      // @ts-ignore
+      navigator.mediaDevices.enumerateDevices.mockResolvedValueOnce(NEW_DEVICE_LIST)
+      const deviceId = await assureDeviceId('2060bf50ab9c29c12598bf4eafeafa71d4837c667c7c172bb4407ec6c5150206', 'FaceTime HD Camera', 'videoinput')
+      expect(deviceId).toEqual('new-uuid')
+      expect(navigator.mediaDevices.enumerateDevices).toHaveBeenCalledTimes(1)
+      done()
     })
 
   })

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [1.2.6] - 2020-02-06
 ### Added
-- New method `assureDeviceId()` to assure the `deviceId` is available after page refresh.
+- New method `validateDeviceId()` to assure the `deviceId` is available after page refresh.
 ### Fixed
 - Make sure `getDevices()` methods always return devices with both deviceId and label even if the browser does not have camera or microphone permissions
 ### Changed

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.2.6] - 2020-02-06
+### Added
+- New method `assureDeviceId()` to assure the `deviceId` is available after page refresh.
 ### Fixed
 - Make sure `getDevices()` methods always return devices with both deviceId and label even if the browser does not have camera or microphone permissions
 ### Changed


### PR DESCRIPTION
Some browsers (spoiler: Safari) generates random `deviceId` on each page loads (on iOS even on location.hash change).
It is common on WebRTC apps to save in localStorage the devices to use the same setup across user navigation.

This PR exposes an internal method to validate a `deviceId` and `label` against the list of devices from the browser. 