### PR TITLE
Add verto.mediaParams support

### DIFF
--- a/packages/common/src/webrtc/BaseCall.ts
+++ b/packages/common/src/webrtc/BaseCall.ts
@@ -78,6 +78,15 @@ export default abstract class BaseCall implements IWebRTCCall {
     this._registerPeerEvents()
   }
 
+  applyMediaConstraints(params: {mediaParams: any}) {
+    const { mediaParams } = params
+    if (mediaParams) {
+
+      Object.keys(mediaParams)
+      .forEach(kind => this.peer.applyMediaConstraints(kind, mediaParams[kind]))
+    }
+  }
+
   hangup(params: any = {}, execute: boolean = true) {
     this.cause = params.cause || 'NORMAL_CLEARING'
     this.causeCode = params.causeCode || 16
@@ -280,6 +289,9 @@ export default abstract class BaseCall implements IWebRTCCall {
         }
         break
       }
+      case VertoMethod.MediaParams:
+        this.applyMediaConstraints(params)
+        break
       case VertoMethod.Bye:
         this.hangup(params, false)
         break

--- a/packages/common/src/webrtc/Peer.ts
+++ b/packages/common/src/webrtc/Peer.ts
@@ -154,4 +154,26 @@ export default class Peer {
     logger.info('RTC config', config)
     return config
   }
+
+  private _getSenderByKind(kind: string) {
+    if (this.instance) {
+      return this.instance.getSenders().find(({ track }) => (track && track.kind === kind))
+    }
+  }
+
+  async applyMediaConstraints(kind: string, constraints: MediaTrackConstraints) {
+    try {
+      const sender = this._getSenderByKind(kind)
+      if (!sender || !sender.track) {
+        return logger.info('No sender to apply constraints', kind, constraints)
+      }
+      if (sender.track.readyState === 'live') {
+        logger.info(`Apply ${kind} constraints`, this.options.id, constraints)
+        await sender.track.applyConstraints(constraints)
+      }
+    } catch (error) {
+      logger.error('Error applying constraints', kind, constraints)
+    }
+
+  }
 }

--- a/packages/common/src/webrtc/VertoHandler.ts
+++ b/packages/common/src/webrtc/VertoHandler.ts
@@ -103,6 +103,8 @@ class VertoHandler {
         params.type = NOTIFICATION_TYPE.vertoClientReady
         trigger(SwEvent.Notification, params, session.uuid)
         break
+
+
       default:
         logger.warn('Verto message unknown method:', msg)
     }

--- a/packages/common/src/webrtc/constants.ts
+++ b/packages/common/src/webrtc/constants.ts
@@ -25,6 +25,7 @@ export enum VertoMethod {
   Unsubscribe = 'verto.unsubscribe',
   ClientReady = 'verto.clientReady',
   Modify = 'verto.modify',
+  MediaParams = 'verto.mediaParams',
 }
 
 export const NOTIFICATION_TYPE = {

--- a/packages/common/tests/webrtc/VertoHandler.ts
+++ b/packages/common/tests/webrtc/VertoHandler.ts
@@ -85,6 +85,48 @@ export default (klass: any) => {
 
     // })
 
+    describe('verto.mediaParams', () => {
+      let handleMessageSpy 
+      beforeEach(async () => {
+        await instance.connect()
+        _setupCall({ id: 'e2fda6dc-fc9d-4d77-8096-53bb502443b6' })
+        const handleMessageSpy = jest.spyOn(call, 'handleMessage');
+        call.hangup = jest.fn()
+        Connection.mockSend.mockClear()
+      })
+
+      it('should pass the msg to the call and invoke the peer applyMediaConstraints for audio', () => {
+        //@ts-expect-error
+        call.peer = { applyMediaConstraints: jest.fn() }
+        const msg = JSON.parse('{"jsonrpc":"2.0","id":1682775,"method":"verto.mediaParams","params":{"callID":"e2fda6dc-fc9d-4d77-8096-53bb502443b6","mediaParams":{"audio":{"autoGainControl":true,"echoCancellation":true,"noiseSuppression":true}}}}')
+        handler.handleMessage(msg)
+        expect(call.handleMessage).toBeCalledTimes(1)
+        expect(call.peer.applyMediaConstraints)
+          .toHaveBeenCalledWith("audio", {"autoGainControl":true,"echoCancellation":true,"noiseSuppression":true})
+      })
+      it('should pass the msg to the call and invoke the peer applyMediaConstraints for video', () => {
+        //@ts-expect-error
+        call.peer = { applyMediaConstraints: jest.fn() }
+        const msg = JSON.parse('{"jsonrpc":"2.0","id":1682775,"method":"verto.mediaParams","params":{"callID":"e2fda6dc-fc9d-4d77-8096-53bb502443b6","mediaParams":{"video":{"autoGainControl":true,"echoCancellation":true,"noiseSuppression":true}}}}')
+        handler.handleMessage(msg)
+        expect(call.handleMessage).toBeCalledTimes(1)
+        expect(call.peer.applyMediaConstraints)
+          .toHaveBeenCalledWith("video", {"autoGainControl":true,"echoCancellation":true,"noiseSuppression":true})
+      })
+      it('should pass the msg to the call and invoke the peer applyMediaConstraints for both', () => {
+        //@ts-expect-error
+        call.peer = { applyMediaConstraints: jest.fn() }
+        const msg = JSON.parse('{"jsonrpc":"2.0","id":1682775,"method":"verto.mediaParams","params":{"callID":"e2fda6dc-fc9d-4d77-8096-53bb502443b6","mediaParams":{"video":{"autoGainControl":true,"echoCancellation":true,"noiseSuppression":true},"audio":{"autoGainControl":true,"echoCancellation":true,"noiseSuppression":true}}}}')
+        handler.handleMessage(msg)
+        expect(call.handleMessage).toBeCalledTimes(1)
+        expect(call.peer.applyMediaConstraints)
+          .toHaveBeenCalledWith("video", {"autoGainControl":true,"echoCancellation":true,"noiseSuppression":true})
+          expect(call.peer.applyMediaConstraints)
+          .toHaveBeenCalledWith("audio", {"autoGainControl":true,"echoCancellation":true,"noiseSuppression":true})
+      })
+    
+    });
+
     describe('verto.info', () => {
       it('should dispatch a notification', () => {
         handler.handleMessage(JSON.parse('{"jsonrpc":"2.0","id":37,"method":"verto.info","params":{"fake":"data", "test": "data"}}'))


### PR DESCRIPTION
Adds support for handling `veto.mediaParams`. This is needed to allow us to tweak the media constraints from the server.
also, `applyMediaContrains` is a public method in the BaseCall that allows us to easily invoke it from the browser console.
