### PR TITLE
Fix loop when an SDP offer is received without video

### DIFF
--- a/packages/common/src/webrtc/BaseCall.ts
+++ b/packages/common/src/webrtc/BaseCall.ts
@@ -171,9 +171,6 @@ export default abstract class BaseCall implements IWebRTCCall {
 
       const { localStream } = this.options
       localStream.getAudioTracks().forEach(t => t.stop())
-
-
-      console.log('____________ getting video tracks <-------------------- (audio)')
       localStream.getVideoTracks().forEach(t => newStream.addTrack(t))
       this.options.localStream = newStream
     }
@@ -203,10 +200,6 @@ export default abstract class BaseCall implements IWebRTCCall {
       this.options.camId = deviceId
 
       localStream.getAudioTracks().forEach(t => newStream.addTrack(t))
-
-      console.log('____________ getting video tracks <-------------------- (video)')
-
-
       localStream.getVideoTracks().forEach(t => t.stop())
       this.options.localStream = newStream
     }

--- a/packages/common/src/webrtc/BaseCall.ts
+++ b/packages/common/src/webrtc/BaseCall.ts
@@ -171,6 +171,9 @@ export default abstract class BaseCall implements IWebRTCCall {
 
       const { localStream } = this.options
       localStream.getAudioTracks().forEach(t => t.stop())
+
+
+      console.log('____________ getting video tracks <-------------------- (audio)')
       localStream.getVideoTracks().forEach(t => newStream.addTrack(t))
       this.options.localStream = newStream
     }
@@ -200,6 +203,10 @@ export default abstract class BaseCall implements IWebRTCCall {
       this.options.camId = deviceId
 
       localStream.getAudioTracks().forEach(t => newStream.addTrack(t))
+
+      console.log('____________ getting video tracks <-------------------- (video)')
+
+
       localStream.getVideoTracks().forEach(t => t.stop())
       this.options.localStream = newStream
     }

--- a/packages/common/src/webrtc/helpers.ts
+++ b/packages/common/src/webrtc/helpers.ts
@@ -310,6 +310,14 @@ const filterIceServers = (servers: RTCIceServer[], options: FilterIceServersOpti
     }))
 }
 
+const sdpHasAudio = (sdp: string = ''): boolean => {
+  return /m=audio/.test(sdp)
+}
+
+const sdpHasVideo = (sdp: string = ''): boolean => {
+  return /m=video/.test(sdp)
+}
+
 export {
   getUserMedia,
   getDevices,
@@ -329,5 +337,7 @@ export {
   enableVideoTracks,
   disableVideoTracks,
   toggleVideoTracks,
-  filterIceServers
+  filterIceServers,
+  sdpHasAudio,
+  sdpHasVideo
 }

--- a/packages/common/src/webrtc/helpers.ts
+++ b/packages/common/src/webrtc/helpers.ts
@@ -5,21 +5,12 @@ import { DeviceType } from './constants'
 import { CallOptions } from './interfaces'
 
 const getUserMedia = async (constraints: MediaStreamConstraints): Promise<MediaStream | null> => {
-
-
-// constraints = { audio: true, video: false}
-
-
   logger.info('RTCService.getUserMedia', constraints)
   const { audio, video } = constraints
   if (!audio && !video) {
     return null
   }
   try {
-
-
-console.log('__________ calling gUM with constraints: ', constraints)
-
     return await WebRTC.getUserMedia(constraints)
   } catch (error) {
     logger.error('getUserMedia error: ', error)
@@ -28,7 +19,6 @@ console.log('__________ calling gUM with constraints: ', constraints)
 }
 
 const _constraintsByKind = (kind: string = null): { audio: boolean, video: boolean } => {
-  console.log('________ kind:', kind)
   return {
     audio: !kind || kind === DeviceType.AudioIn,
     video: !kind || kind === DeviceType.Video
@@ -47,11 +37,6 @@ const getDevices = async (kind: string = null, fullList: boolean = false): Promi
   }
   const valid: boolean = devices.length && devices.every((d: MediaDeviceInfo) => (d.deviceId && d.label))
   if (!valid) {
-
-
-
-console.log('___________ calling gUM inside getDevices _________ kind:', kind)
-
     const stream = await WebRTC.getUserMedia(_constraintsByKind(kind))
     WebRTC.stopStream(stream)
     return getDevices(kind)
@@ -78,11 +63,6 @@ console.log('___________ calling gUM inside getDevices _________ kind:', kind)
 const resolutionList = [[320, 240], [640, 360], [640, 480], [1280, 720], [1920, 1080]]
 const scanResolutions = async (deviceId: string) => {
   const supported = []
-
-
-  console.log('___________ calling gUM inside scanResolutions _________')
-
-
   const stream = await getUserMedia({ video: { deviceId: { exact: deviceId } } })
   const videoTrack = stream.getVideoTracks()[0]
   for (let i = 0; i < resolutionList.length; i++) {
@@ -123,8 +103,6 @@ const getMediaConstraints = async (options: CallOptions): Promise<MediaStreamCon
       video.deviceId = { exact: camId }
     }
   }
-
-  console.log('_______INSIDE getMediaContraints________ audio: ', audio, ' - video: ', video)
 
   return { audio, video }
 }

--- a/packages/common/src/webrtc/helpers.ts
+++ b/packages/common/src/webrtc/helpers.ts
@@ -5,12 +5,21 @@ import { DeviceType } from './constants'
 import { CallOptions } from './interfaces'
 
 const getUserMedia = async (constraints: MediaStreamConstraints): Promise<MediaStream | null> => {
+
+
+// constraints = { audio: true, video: false}
+
+
   logger.info('RTCService.getUserMedia', constraints)
   const { audio, video } = constraints
   if (!audio && !video) {
     return null
   }
   try {
+
+
+console.log('__________ calling gUM with constraints: ', constraints)
+
     return await WebRTC.getUserMedia(constraints)
   } catch (error) {
     logger.error('getUserMedia error: ', error)
@@ -19,6 +28,7 @@ const getUserMedia = async (constraints: MediaStreamConstraints): Promise<MediaS
 }
 
 const _constraintsByKind = (kind: string = null): { audio: boolean, video: boolean } => {
+  console.log('________ kind:', kind)
   return {
     audio: !kind || kind === DeviceType.AudioIn,
     video: !kind || kind === DeviceType.Video
@@ -37,6 +47,11 @@ const getDevices = async (kind: string = null, fullList: boolean = false): Promi
   }
   const valid: boolean = devices.length && devices.every((d: MediaDeviceInfo) => (d.deviceId && d.label))
   if (!valid) {
+
+
+
+console.log('___________ calling gUM inside getDevices _________ kind:', kind)
+
     const stream = await WebRTC.getUserMedia(_constraintsByKind(kind))
     WebRTC.stopStream(stream)
     return getDevices(kind)
@@ -63,6 +78,11 @@ const getDevices = async (kind: string = null, fullList: boolean = false): Promi
 const resolutionList = [[320, 240], [640, 360], [640, 480], [1280, 720], [1920, 1080]]
 const scanResolutions = async (deviceId: string) => {
   const supported = []
+
+
+  console.log('___________ calling gUM inside scanResolutions _________')
+
+
   const stream = await getUserMedia({ video: { deviceId: { exact: deviceId } } })
   const videoTrack = stream.getVideoTracks()[0]
   for (let i = 0; i < resolutionList.length; i++) {
@@ -103,6 +123,8 @@ const getMediaConstraints = async (options: CallOptions): Promise<MediaStreamCon
       video.deviceId = { exact: camId }
     }
   }
+
+  console.log('_______INSIDE getMediaContraints________ audio: ', audio, ' - video: ', video)
 
   return { audio, video }
 }


### PR DESCRIPTION
When an SDP offer is received without video, the current code still performs a `getUserMedia()` request with `video` set to `true`.

Then the local streams are added to the RTCPeerConnection, before the remote description has been added to it.

This triggers an additional `onnegotiationneeded` that calls `startNegotiating()` again, which in turns calls `_createAnswer()` again, which will trigger new `onnegotiationneeded` events in a loop that continues for the duration of a session.

I'm not sure about the side effect of this loop, but I'm concerned it may appear as missing ICE candidates in the answer SDP, as if the loop is impacting the correct addition of ICE candidates to the answer SDP that's being built.

To reproduce this and see the loop:
1. Add a log line inside `onnegotiationneeded`
2. Send an audio-only offer to the running client

With the changes in this PR instead the constraint for getUserMedia will depend on the combination of available devices and what was received in the offer. An audio-only offer will only cause a getUserMedia with `video` `false`.