### PR TITLE
Keep the negotiating state until the SDP is ready

### DIFF
--- a/packages/common/src/webrtc/BaseCall.ts
+++ b/packages/common/src/webrtc/BaseCall.ts
@@ -623,6 +623,8 @@ export default abstract class BaseCall implements IWebRTCCall {
   }
 
   private _requestAnotherLocalDescription() {
+    logger.debug('_requestAnotherLocalDescription')
+
     if (isFunction(this.peer.onSdpReadyTwice)) {
       trigger(SwEvent.Error, new Error('SDP without candidates for the second time!'), this.session.uuid)
       return
@@ -633,11 +635,16 @@ export default abstract class BaseCall implements IWebRTCCall {
   }
 
   private _onIceSdp(data: RTCSessionDescription) {
+    logger.debug('_onIceSdp')
+
     if (this._iceTimeout) {
       clearTimeout(this._iceTimeout)
     }
     this._iceTimeout = null
     this._iceDone = true
+
+    this.peer.resetNegotiating()
+
     const { sdp, type } = data
     if (sdp.indexOf('candidate') === -1) {
       this._requestAnotherLocalDescription()
@@ -678,10 +685,11 @@ export default abstract class BaseCall implements IWebRTCCall {
         return
       }
       if (this._iceTimeout === null) {
+        logger.debug('Setting _iceTimeout to 1 second')
         this._iceTimeout = setTimeout(() => this._onIceSdp(instance.localDescription), 1000)
       }
       if (event.candidate) {
-        logger.info('IceCandidate:', event.candidate)
+        logger.debug('IceCandidate: address:', event.candidate.address, ' - port:', event.candidate.port, ' - type:', event.candidate.type)
       } else {
         this._onIceSdp(instance.localDescription)
       }

--- a/packages/common/src/webrtc/Peer.ts
+++ b/packages/common/src/webrtc/Peer.ts
@@ -15,6 +15,14 @@ export default class Peer {
   private _constraints: { offerToReceiveAudio: boolean, offerToReceiveVideo: boolean }
   private _negotiating: boolean = false
 
+  resetNegotiating() {
+    this._negotiating = false
+  }
+
+  isNegotiating() {
+    return this._negotiating
+  }
+
   constructor(public type: PeerType, private options: CallOptions) {
     logger.info('New Peer with type:', this.type, 'Options:', this.options)
 
@@ -39,9 +47,6 @@ export default class Peer {
     this.instance.onsignalingstatechange = event => {
       switch (this.instance.signalingState) {
         case 'stable':
-          // Workaround to skip nested negotiations
-          // Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=740501
-          this._negotiating = false
           break
         case 'closed':
           this.instance = null
@@ -114,6 +119,7 @@ export default class Peer {
     if (googleMaxBitrate && googleMinBitrate && googleStartBitrate) {
       sessionDescription.sdp = sdpBitrateHack(sessionDescription.sdp, googleMaxBitrate, googleMinBitrate, googleStartBitrate)
     }
+    logger.debug('calling setLocalDescription with SDP:', sessionDescription.sdp)
     return this.instance.setLocalDescription(sessionDescription)
   }
 

--- a/packages/common/src/webrtc/Peer.ts
+++ b/packages/common/src/webrtc/Peer.ts
@@ -15,20 +15,20 @@ export default class Peer {
   private _constraints: { offerToReceiveAudio: boolean, offerToReceiveVideo: boolean }
   private _negotiating: boolean = false
 
-  resetNegotiating() {
-    this._negotiating = false
-  }
-
-  isNegotiating() {
-    return this._negotiating
-  }
-
   constructor(public type: PeerType, private options: CallOptions) {
     logger.info('New Peer with type:', this.type, 'Options:', this.options)
 
     this._constraints = { offerToReceiveAudio: true, offerToReceiveVideo: true }
     this._sdpReady = this._sdpReady.bind(this)
     this._init()
+  }
+
+  resetNegotiating() {
+    this._negotiating = false
+  }
+
+  get isNegotiating() {
+    return this._negotiating
   }
 
   startNegotiation() {


### PR DESCRIPTION
When answering a call, when setting the remote description the signaling state moves to `have-remote-offer`.
Peer's `_negotiating` is set to true, to prevent triggering new negotiations during this phase.

However, when setting the local description, while the ICE candidates haven't been gathered yet, the signaling state  moves to `stable`.

A new `onnegotiationneeded` at that point would trigger a new negotiation, which is not desired, and a loop starts, continuing during the call itself.

This is invisible unless debug logging is activated, but has the side effect of causing some ICE candidates to be excluded from the SDP before it's transmitted. This _per se_ doesn't cause the call to fail, which made the bug harder to track.

With the changes in this PR though, the "negotiating" state is kept in the Peer until the final SDP will be ready.

In my tests this proved to fix the issue with the infinite loop and the missing candidates.

Admittedly, I haven't tested the case of the Peer generating a call, which is a scenario that shares some of the change code, but I've only tested the case of the Peer receiving a call.