### PR TITLE
Add custom cause code to the `verto.bye`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ This package provides a client for Signalwire services and supports different Ja
 
 ### Packages
 
-| Project | Description | README | CHANGELOG | Version |
-| ------- | ------- | ------- | ------- |:-----:|
-| **Node.js** | SignalWire in Node.js | [`README.md`](packages/node/README.md) | [`CHANGELOG.md`](packages/node/CHANGELOG.md) | ![NPM](https://img.shields.io/npm/v/@signalwire/node.svg?color=brightgreen)
-| **JavaScript** | SignalWire in the browser! | [`README.md`](packages/js/README.md) | [`CHANGELOG.md`](packages/js/CHANGELOG.md) | ![NPM](https://img.shields.io/npm/v/@signalwire/js/legacy.svg?color=brightgreen)
-| **React Native** | SignalWire in a React Native App | [`README.md`](packages/react-native/README.md) | [`CHANGELOG.md`](packages/react-native/CHANGELOG.md) | ![NPM](https://img.shields.io/npm/v/@signalwire/react-native.svg?color=brightgreen)
+| Project          | Description                      | README                                         | CHANGELOG                                            |                                       Version                                       |
+| ---------------- | -------------------------------- | ---------------------------------------------- | ---------------------------------------------------- | :---------------------------------------------------------------------------------: |
+| **Node.js**      | SignalWire in Node.js            | [`README.md`](packages/node/README.md)         | [`CHANGELOG.md`](packages/node/CHANGELOG.md)         |     ![NPM](https://img.shields.io/npm/v/@signalwire/node.svg?color=brightgreen)     |
+| **JavaScript**   | SignalWire in the browser!       | [`README.md`](packages/js/README.md)           | [`CHANGELOG.md`](packages/js/CHANGELOG.md)           |  ![NPM](https://img.shields.io/npm/v/@signalwire/js/legacy.svg?color=brightgreen)   |
+| **React Native** | SignalWire in a React Native App | [`README.md`](packages/react-native/README.md) | [`CHANGELOG.md`](packages/react-native/CHANGELOG.md) | ![NPM](https://img.shields.io/npm/v/@signalwire/react-native.svg?color=brightgreen) |
 
 Refer to the README of each package for further details.
 
@@ -21,12 +21,15 @@ The SDK now properly reports error causes when calls are terminated due to excep
 ### Error Payload Examples
 
 #### Normal Call Clearing
+
 ```json
 {
   "method": "verto.bye",
   "params": {
     "sessid": "session-id",
-    "dialogParams": { /* ... */ },
+    "dialogParams": {
+      /* ... */
+    },
     "cause": "NORMAL_CLEARING",
     "causeCode": 16
   }
@@ -34,39 +37,48 @@ The SDK now properly reports error causes when calls are terminated due to excep
 ```
 
 #### Error Setting Remote SDP
+
 ```json
 {
   "method": "verto.bye",
   "params": {
     "sessid": "session-id",
-    "dialogParams": { /* ... */ },
-    "cause": "ERROR_SETTING_REMOTE_SDP",
+    "dialogParams": {
+      /* ... */
+    },
+    "cause": "WRONG_CALL_STATE",
     "causeCode": 666
   }
 }
 ```
 
 #### Error Sending Answer
+
 ```json
 {
   "method": "verto.bye",
   "params": {
     "sessid": "session-id",
-    "dialogParams": { /* ... */ },
-    "cause": "ERROR_SENDING_ANSWER",
+    "dialogParams": {
+      /* ... */
+    },
+    "cause": "NORMAL_TEMPORARY_FAILURE",
     "causeCode": 666
   }
 }
 ```
 
 #### Error Sending Attach
+
 ```json
 {
   "method": "verto.bye",
   "params": {
     "sessid": "session-id",
-    "dialogParams": { /* ... */ },
-    "cause": "ERROR_SENDING_ATTACH",
+    "dialogParams": {
+      /* ... */
+    },
+    "cause": "NORMAL_TEMPORARY_FAILURE",
     "causeCode": 666
   }
 }
@@ -74,9 +86,9 @@ The SDK now properly reports error causes when calls are terminated due to excep
 
 ### Error Causes
 
-- **ERROR_SETTING_REMOTE_SDP**: Failed to set the remote session description during WebRTC negotiation
-- **ERROR_SENDING_ANSWER**: Failed to send an answer message to the server
-- **ERROR_SENDING_ATTACH**: Failed to send an attach message to the server
+- **WRONG_CALL_STATE**: Failed to set the remote session description during WebRTC negotiation
+- **NORMAL_TEMPORARY_FAILURE**: Failed to send an answer message to the server
+- **NORMAL_TEMPORARY_FAILURE**: Failed to send an attach message to the server
 
 All error causes use the special error code `666` to distinguish them from standard telephony cause codes.
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ The SDK now properly reports error causes when calls are terminated due to excep
     "dialogParams": {
       /* ... */
     },
-    "cause": "WRONG_CALL_STATE",
-    "causeCode": 666
+    "cause": "NORMAL_CLEARING",
+    "causeCode": 50004
   }
 }
 ```
@@ -62,8 +62,8 @@ The SDK now properly reports error causes when calls are terminated due to excep
     "dialogParams": {
       /* ... */
     },
-    "cause": "NORMAL_TEMPORARY_FAILURE",
-    "causeCode": 666
+    "cause": "NORMAL_CLEARING",
+    "causeCode": 50001
   }
 }
 ```
@@ -78,17 +78,18 @@ The SDK now properly reports error causes when calls are terminated due to excep
     "dialogParams": {
       /* ... */
     },
-    "cause": "NORMAL_TEMPORARY_FAILURE",
-    "causeCode": 666
+    "cause": "NORMAL_CLEARING",
+    "causeCode": 50002
   }
 }
 ```
 
-### Error Causes
+### Error Cause Codes
 
-- **WRONG_CALL_STATE**: Failed to set the remote session description during WebRTC negotiation
-- **NORMAL_TEMPORARY_FAILURE**: Failed to send an answer message to the server
-- **NORMAL_TEMPORARY_FAILURE**: Failed to send an attach message to the server
+- **REMOTE_SDP_ERROR_CAUSE_CODE 50004**: Failed to set the remote session description during WebRTC negotiation
+- **EXECUTE_ANSWER_ERROR_CAUSE_CODE 50001**: Failed to send an answer message to the server
+- **EXECUTE_ATTACH_ERROR_CAUSE_CODE 50002**: Failed to send an attach message to the server
+- **EXECUTE_INVITE_ERROR_CAUSE_CODE 50003**: Failed to send an invite message to the server
 
 All error causes use the special error code `666` to distinguish them from standard telephony cause codes.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,72 @@ This package provides a client for Signalwire services and supports different Ja
 
 Refer to the README of each package for further details.
 
+## Hangup Error Handling
+
+The SDK now properly reports error causes when calls are terminated due to exceptions. When an error occurs during call setup or negotiation, the `verto.bye` message will include specific error information instead of the generic `NORMAL_CLEARING` cause.
+
+### Error Payload Examples
+
+#### Normal Call Clearing
+```json
+{
+  "method": "verto.bye",
+  "params": {
+    "sessid": "session-id",
+    "dialogParams": { /* ... */ },
+    "cause": "NORMAL_CLEARING",
+    "causeCode": 16
+  }
+}
+```
+
+#### Error Setting Remote SDP
+```json
+{
+  "method": "verto.bye",
+  "params": {
+    "sessid": "session-id",
+    "dialogParams": { /* ... */ },
+    "cause": "ERROR_SETTING_REMOTE_SDP",
+    "causeCode": 666
+  }
+}
+```
+
+#### Error Sending Answer
+```json
+{
+  "method": "verto.bye",
+  "params": {
+    "sessid": "session-id",
+    "dialogParams": { /* ... */ },
+    "cause": "ERROR_SENDING_ANSWER",
+    "causeCode": 666
+  }
+}
+```
+
+#### Error Sending Attach
+```json
+{
+  "method": "verto.bye",
+  "params": {
+    "sessid": "session-id",
+    "dialogParams": { /* ... */ },
+    "cause": "ERROR_SENDING_ATTACH",
+    "causeCode": 666
+  }
+}
+```
+
+### Error Causes
+
+- **ERROR_SETTING_REMOTE_SDP**: Failed to set the remote session description during WebRTC negotiation
+- **ERROR_SENDING_ANSWER**: Failed to send an answer message to the server
+- **ERROR_SENDING_ATTACH**: Failed to send an attach message to the server
+
+All error causes use the special error code `666` to distinguish them from standard telephony cause codes.
+
 ## License
 
 Copyright © 2018-2019 SignalWire. It is free software, and may be redistributed under the terms specified in the MIT-LICENSE file.

--- a/packages/common/src/webrtc/BaseCall.ts
+++ b/packages/common/src/webrtc/BaseCall.ts
@@ -45,8 +45,8 @@ import {
 import { MCULayoutEventHandler } from './LayoutHandler'
 
 // Error code for hangup when caused by an error
-const HANGUP_CAUSE_CODE_ERROR = 666
-
+export const NORMAL_TEMPORARY_FAILURE_CODE = 666
+export const WRONG_CALL_STATE_CODE = 666
 export default abstract class BaseCall implements IWebRTCCall {
   public id: string = ''
   public state: string = State[State.New]
@@ -838,8 +838,8 @@ export default abstract class BaseCall implements IWebRTCCall {
       .catch((error) => {
         logger.error('Call setRemoteDescription Error: ', error)
         this.hangup({
-          cause: 'ERROR_SETTING_REMOTE_SDP',
-          causeCode: HANGUP_CAUSE_CODE_ERROR,
+          cause: 'WRONG_CALL_STATE',
+          causeCode: WRONG_CALL_STATE_CODE,
         })
       })
   }
@@ -910,19 +910,8 @@ export default abstract class BaseCall implements IWebRTCCall {
       })
       .catch((error) => {
         logger.error(`${this.id} - Sending ${type} error:`, error)
-        let cause = 'ERROR_SENDING_VERTO_MSG'
-        switch (msg.toString()) {
-          case VertoMethod.Invite:
-            cause = 'ERROR_SENDING_INVITE'
-            break
-          case VertoMethod.Answer:
-            cause = 'ERROR_SENDING_ANSWER'
-            break
-          case VertoMethod.Attach:
-            cause = 'ERROR_SENDING_ANSWER'
-            break
-        }
-        this.hangup({ cause, causeCode: HANGUP_CAUSE_CODE_ERROR })
+        let cause = 'NORMAL_TEMPORARY_FAILURE'
+        this.hangup({ cause, causeCode: NORMAL_TEMPORARY_FAILURE_CODE })
       })
   }
 

--- a/packages/common/src/webrtc/BaseCall.ts
+++ b/packages/common/src/webrtc/BaseCall.ts
@@ -45,8 +45,10 @@ import {
 import { MCULayoutEventHandler } from './LayoutHandler'
 
 // Error code for hangup when caused by an error
-export const NORMAL_TEMPORARY_FAILURE_CODE = 666
-export const WRONG_CALL_STATE_CODE = 666
+export const EXECUTE_ANSWER_ERROR_CAUSE_CODE = 50001
+export const EXECUTE_ATTACH_ERROR_CAUSE_CODE = 50002
+export const EXECUTE_INVITE_ERROR_CAUSE_CODE = 50003
+export const REMOTE_SDP_ERROR_CAUSE_CODE = 50004
 export default abstract class BaseCall implements IWebRTCCall {
   public id: string = ''
   public state: string = State[State.New]
@@ -838,8 +840,8 @@ export default abstract class BaseCall implements IWebRTCCall {
       .catch((error) => {
         logger.error('Call setRemoteDescription Error: ', error)
         this.hangup({
-          cause: 'WRONG_CALL_STATE',
-          causeCode: WRONG_CALL_STATE_CODE,
+          cause: 'NORMAL_CLEARING',
+          causeCode: REMOTE_SDP_ERROR_CAUSE_CODE,
         })
       })
   }
@@ -910,8 +912,16 @@ export default abstract class BaseCall implements IWebRTCCall {
       })
       .catch((error) => {
         logger.error(`${this.id} - Sending ${type} error:`, error)
-        let cause = 'NORMAL_TEMPORARY_FAILURE'
-        this.hangup({ cause, causeCode: NORMAL_TEMPORARY_FAILURE_CODE })
+        let causeCode
+        switch (msg.toSring()) {
+          case VertoMethod.Answer:
+            causeCode = EXECUTE_ANSWER_ERROR_CAUSE_CODE
+          case VertoMethod.Attach:
+            causeCode = EXECUTE_ATTACH_ERROR_CAUSE_CODE
+          case VertoMethod.Invite:
+            causeCode = EXECUTE_INVITE_ERROR_CAUSE_CODE
+        }
+        this.hangup({ cause: 'NORMAL_CLEARING', causeCode })
       })
   }
 

--- a/packages/common/tests/webrtc/BaseCall.test.ts
+++ b/packages/common/tests/webrtc/BaseCall.test.ts
@@ -1,0 +1,191 @@
+import BaseCall from '../../src/webrtc/BaseCall'
+import { Bye } from '../../src/messages/Verto'
+import { State } from '../../src/webrtc/constants'
+
+// Mock dependencies
+jest.mock('../../src/messages/Verto')
+jest.mock('../../src/util/logger', () => {
+  return {
+    __esModule: true,
+    default: {
+      trace: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    },
+  }
+})
+
+// Get mocked version
+const MockedBye = Bye as jest.MockedClass<typeof Bye>
+
+// Create a concrete implementation of the abstract BaseCall class for testing
+class TestCall extends BaseCall {
+  constructor(session, opts) {
+    super(session, opts)
+  }
+
+  invite() {
+    throw new Error('Method not implemented.')
+  }
+
+  answer(params) {
+    throw new Error('Method not implemented.')
+  }
+
+  // Add protected method accessor for testing
+  testExecute(msg) {
+    return this['_execute'](msg)
+  }
+}
+
+describe('BaseCall', () => {
+  let mockSession
+  let call
+  let mockExecute
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockExecute = jest.fn().mockResolvedValue({})
+
+    mockSession = {
+      sessionid: 'test-session-id',
+      execute: mockExecute,
+      uuid: 'test-uuid',
+      mediaConstraints: {
+        audio: true,
+        video: false,
+      },
+      options: {
+        userVariables: {},
+      },
+      calls: {},
+    }
+
+    call = new TestCall(mockSession, {
+      id: 'test-call-id',
+      destinationNumber: '1234567890',
+    })
+
+    // Mock the internal execute method by overriding it directly
+    call['_execute'] = mockExecute
+
+    // Mock peer if needed
+    call.peer = {
+      instance: {
+        close: jest.fn(),
+      },
+    }
+  })
+
+  describe('hangup method', () => {
+    describe('cause and causeCode handling', () => {
+      it('should use default cause and causeCode when not provided', () => {
+        call.hangup()
+
+        expect(call.cause).toBe('NORMAL_CLEARING')
+        expect(call.causeCode).toBe(16)
+      })
+
+      it('should use custom cause and causeCode when provided', () => {
+        call.hangup({ cause: 'USER_BUSY', causeCode: 17 })
+
+        expect(call.cause).toBe('USER_BUSY')
+        expect(call.causeCode).toBe(17)
+      })
+
+      it('should use error cause and code for ERROR_SETTING_REMOTE_SDP', () => {
+        call.hangup({ cause: 'ERROR_SETTING_REMOTE_SDP', causeCode: 666 })
+
+        expect(call.cause).toBe('ERROR_SETTING_REMOTE_SDP')
+        expect(call.causeCode).toBe(666)
+      })
+
+      it('should use error cause and code for ERROR_SENDING_ANSWER', () => {
+        call.hangup({ cause: 'ERROR_SENDING_ANSWER', causeCode: 666 })
+
+        expect(call.cause).toBe('ERROR_SENDING_ANSWER')
+        expect(call.causeCode).toBe(666)
+      })
+
+      it('should use error cause and code for ERROR_SENDING_ATTACH', () => {
+        call.hangup({ cause: 'ERROR_SENDING_ATTACH', causeCode: 666 })
+
+        expect(call.cause).toBe('ERROR_SENDING_ATTACH')
+        expect(call.causeCode).toBe(666)
+      })
+    })
+
+    describe('Bye message creation', () => {
+      it('should create Bye message with cause and causeCode when execute is true', () => {
+        const mockByeInstance = { method: 'verto.bye' } as any
+        MockedBye.mockImplementation(() => mockByeInstance)
+
+        call.hangup({ cause: 'TEST_CAUSE', causeCode: 999 })
+
+        expect(MockedBye).toHaveBeenCalledWith({
+          sessid: 'test-session-id',
+          dialogParams: call.options,
+          cause: 'TEST_CAUSE',
+          causeCode: 999,
+        })
+      })
+
+      it('should not create Bye message when execute is false', () => {
+        call.hangup({}, false)
+
+        expect(MockedBye).not.toHaveBeenCalled()
+      })
+
+      it('should execute the Bye message when execute is true', () => {
+        const mockByeInstance = { method: 'verto.bye' } as any
+        MockedBye.mockImplementation(() => mockByeInstance)
+
+        call.hangup()
+
+        expect(mockExecute).toHaveBeenCalledWith(mockByeInstance)
+      })
+    })
+  })
+
+  describe('verto.bye message payload', () => {
+    it('should include cause and causeCode in the Bye message parameters', () => {
+      const mockByeInstance = { method: 'verto.bye' } as any
+      MockedBye.mockImplementation(() => mockByeInstance)
+
+      call.hangup({ cause: 'CUSTOM_CAUSE', causeCode: 123 })
+
+      const byeCallArgs = MockedBye.mock.calls[0][0]
+      expect(byeCallArgs).toEqual({
+        sessid: 'test-session-id',
+        dialogParams: call.options,
+        cause: 'CUSTOM_CAUSE',
+        causeCode: 123,
+      })
+    })
+
+    it('should include session ID and dialog parameters', () => {
+      const mockByeInstance = { method: 'verto.bye' } as any
+      MockedBye.mockImplementation(() => mockByeInstance)
+
+      call.hangup()
+
+      const byeCallArgs = MockedBye.mock.calls[0][0]
+      expect(byeCallArgs.sessid).toBe('test-session-id')
+      expect(byeCallArgs.dialogParams).toBe(call.options)
+    })
+
+    it('should use default values when no parameters provided', () => {
+      const mockByeInstance = { method: 'verto.bye' } as any
+      MockedBye.mockImplementation(() => mockByeInstance)
+
+      call.hangup()
+
+      const byeCallArgs = MockedBye.mock.calls[0][0]
+      expect(byeCallArgs.cause).toBe('NORMAL_CLEARING')
+      expect(byeCallArgs.causeCode).toBe(16)
+    })
+  })
+})

--- a/packages/common/tests/webrtc/BaseCall.test.ts
+++ b/packages/common/tests/webrtc/BaseCall.test.ts
@@ -1,4 +1,4 @@
-import BaseCall from '../../src/webrtc/BaseCall'
+import BaseCall, { NORMAL_TEMPORARY_FAILURE_CODE, WRONG_CALL_STATE_CODE } from '../../src/webrtc/BaseCall'
 import { Bye } from '../../src/messages/Verto'
 import { State } from '../../src/webrtc/constants'
 
@@ -96,25 +96,25 @@ describe('BaseCall', () => {
         expect(call.causeCode).toBe(17)
       })
 
-      it('should use error cause and code for ERROR_SETTING_REMOTE_SDP', () => {
-        call.hangup({ cause: 'ERROR_SETTING_REMOTE_SDP', causeCode: 666 })
+      it('should use error cause and code for WRONG_CALL_STATE', () => {
+        call.hangup({ cause: 'WRONG_CALL_STATE', causeCode: WRONG_CALL_STATE_CODE })
 
-        expect(call.cause).toBe('ERROR_SETTING_REMOTE_SDP')
-        expect(call.causeCode).toBe(666)
+        expect(call.cause).toBe('WRONG_CALL_STATE')
+        expect(call.causeCode).toBe(NORMAL_TEMPORARY_FAILURE_CODE)
       })
 
-      it('should use error cause and code for ERROR_SENDING_ANSWER', () => {
-        call.hangup({ cause: 'ERROR_SENDING_ANSWER', causeCode: 666 })
+      it('should use error cause and code for NORMAL_TEMPORARY_FAILURE', () => {
+        call.hangup({ cause: 'NORMAL_TEMPORARY_FAILURE', causeCode: NORMAL_TEMPORARY_FAILURE_CODE })
 
-        expect(call.cause).toBe('ERROR_SENDING_ANSWER')
-        expect(call.causeCode).toBe(666)
+        expect(call.cause).toBe('NORMAL_TEMPORARY_FAILURE')
+        expect(call.causeCode).toBe(NORMAL_TEMPORARY_FAILURE_CODE)
       })
 
-      it('should use error cause and code for ERROR_SENDING_ATTACH', () => {
-        call.hangup({ cause: 'ERROR_SENDING_ATTACH', causeCode: 666 })
+      it('should use error cause and code for NORMAL_TEMPORARY_FAILURE', () => {
+        call.hangup({ cause: 'NORMAL_TEMPORARY_FAILURE', causeCode: NORMAL_TEMPORARY_FAILURE_CODE })
 
-        expect(call.cause).toBe('ERROR_SENDING_ATTACH')
-        expect(call.causeCode).toBe(666)
+        expect(call.cause).toBe('NORMAL_TEMPORARY_FAILURE')
+        expect(call.causeCode).toBe(NORMAL_TEMPORARY_FAILURE_CODE)
       })
     })
 

--- a/packages/common/tests/webrtc/BaseCall.test.ts
+++ b/packages/common/tests/webrtc/BaseCall.test.ts
@@ -1,4 +1,8 @@
-import BaseCall, { NORMAL_TEMPORARY_FAILURE_CODE, WRONG_CALL_STATE_CODE } from '../../src/webrtc/BaseCall'
+import BaseCall, {
+  EXECUTE_ANSWER_ERROR_CAUSE_CODE,
+  EXECUTE_ATTACH_ERROR_CAUSE_CODE,
+  REMOTE_SDP_ERROR_CAUSE_CODE,
+} from '../../src/webrtc/BaseCall'
 import { Bye } from '../../src/messages/Verto'
 import { State } from '../../src/webrtc/constants'
 
@@ -96,25 +100,34 @@ describe('BaseCall', () => {
         expect(call.causeCode).toBe(17)
       })
 
-      it('should use error cause and code for WRONG_CALL_STATE', () => {
-        call.hangup({ cause: 'WRONG_CALL_STATE', causeCode: WRONG_CALL_STATE_CODE })
+      it('should use error cause and code for REMOTE_SDP_ERROR_CAUSE_CODE', () => {
+        call.hangup({
+          cause: 'NORMAL_CLEARING',
+          causeCode: REMOTE_SDP_ERROR_CAUSE_CODE,
+        })
 
-        expect(call.cause).toBe('WRONG_CALL_STATE')
-        expect(call.causeCode).toBe(NORMAL_TEMPORARY_FAILURE_CODE)
+        expect(call.cause).toBe('NORMAL_CLEARING')
+        expect(call.causeCode).toBe(REMOTE_SDP_ERROR_CAUSE_CODE)
       })
 
-      it('should use error cause and code for NORMAL_TEMPORARY_FAILURE', () => {
-        call.hangup({ cause: 'NORMAL_TEMPORARY_FAILURE', causeCode: NORMAL_TEMPORARY_FAILURE_CODE })
+      it('should use error cause and code for EXECUTE_ANSWER_ERROR_CAUSE_CODE', () => {
+        call.hangup({
+          cause: 'NORMAL_CLEARING',
+          causeCode: EXECUTE_ANSWER_ERROR_CAUSE_CODE,
+        })
 
-        expect(call.cause).toBe('NORMAL_TEMPORARY_FAILURE')
-        expect(call.causeCode).toBe(NORMAL_TEMPORARY_FAILURE_CODE)
+        expect(call.cause).toBe('NORMAL_CLEARING')
+        expect(call.causeCode).toBe(EXECUTE_ANSWER_ERROR_CAUSE_CODE)
       })
 
-      it('should use error cause and code for NORMAL_TEMPORARY_FAILURE', () => {
-        call.hangup({ cause: 'NORMAL_TEMPORARY_FAILURE', causeCode: NORMAL_TEMPORARY_FAILURE_CODE })
+      it('should use error cause and code for EXECUTE_ATTACH_ERROR_CAUSE_CODE', () => {
+        call.hangup({
+          cause: 'NORMAL_CLEARING',
+          causeCode: EXECUTE_ATTACH_ERROR_CAUSE_CODE,
+        })
 
-        expect(call.cause).toBe('NORMAL_TEMPORARY_FAILURE')
-        expect(call.causeCode).toBe(NORMAL_TEMPORARY_FAILURE_CODE)
+        expect(call.cause).toBe('NORMAL_CLEARING')
+        expect(call.causeCode).toBe(EXECUTE_ATTACH_ERROR_CAUSE_CODE)
       })
     })
 


### PR DESCRIPTION
The SDK now properly reports error causes when calls are terminated due to exceptions. When an error occurs during call setup or negotiation, the `verto.bye` message will include specific error information instead of the generic `NORMAL_CLEARING` cause.

### Error Payload Examples

#### Normal Call Clearing

```json
{
  "method": "verto.bye",
  "params": {
    "sessid": "session-id",
    "dialogParams": {
      /* ... */
    },
    "cause": "NORMAL_CLEARING",
    "causeCode": 16
  }
}
```

#### Error Setting Remote SDP

```json
{
  "method": "verto.bye",
  "params": {
    "sessid": "session-id",
    "dialogParams": {
      /* ... */
    },
    "cause": "NORMAL_CLEARING",
    "causeCode": 50004
  }
}
```

#### Error Sending Answer

```json
{
  "method": "verto.bye",
  "params": {
    "sessid": "session-id",
    "dialogParams": {
      /* ... */
    },
    "cause": "NORMAL_CLEARING",
    "causeCode": 50001
  }
}
```

#### Error Sending Attach

```json
{
  "method": "verto.bye",
  "params": {
    "sessid": "session-id",
    "dialogParams": {
      /* ... */
    },
    "cause": "NORMAL_CLEARING",
    "causeCode": 50002
  }
}
```